### PR TITLE
Looking for *.app instead of Firefox*.app in OSX pkg

### DIFF
--- a/firefox_app.py
+++ b/firefox_app.py
@@ -13,7 +13,7 @@ class FirefoxApp(object):
 
     __locations = {
         "osx": {
-            "base": os.path.join("*", "Firefox*.app"),
+            "base": os.path.join("*", "*.app"),
             "exe": os.path.join("Contents", "MacOS", "firefox"),
             "browser": os.path.join("Contents", "Resources", "browser"),
             "gredir": os.path.join("Contents", "Resources"),


### PR DESCRIPTION
This is a trivial fix for #54. This PR replaces the PR
from the misnamed branch in #70.