### PR TITLE
Adding PEP8 pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ venv\Scripts\activate
 pip install -e .
 ```
 
+### Note for developers
+There's a pre-commit hook for git that you can use for checking for PEP8 violations. You can install it
+by running
+```
+ln -sf ../../hooks/pre-commit .git/hooks/
+```
+
 ### Command line arguments
 Argument | Choices / **default** | Description
 ----------|----------|----------

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""
+Originally forked from ``https://gist.github.com/810399``
+
+Altered by @cr for the TLS Canary project
+"""
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def system(*args, **kwargs):
+    kwargs.setdefault('stdout', subprocess.PIPE)
+    proc = subprocess.Popen(args, **kwargs)
+    out, err = proc.communicate()
+    return out
+
+
+def ignore_file(filename):
+    ignored = []
+    match = False
+    for i in ignored:
+        if i in filename:
+            match = True
+    return match
+
+
+def main():
+    modified = re.compile('^[AM]+\s+(?P<name>.*\.py)', re.MULTILINE)
+    files = system('git', 'status', '--porcelain')
+    files = modified.findall(files)
+
+    tempdir = tempfile.mkdtemp()
+    for name in files:
+        filename = os.path.join(tempdir, name)
+
+        if not ignore_file(filename):
+            filepath = os.path.dirname(filename)
+            if not os.path.exists(filepath):
+                os.makedirs(filepath)
+            with file(filename, 'w') as f:
+                system('git', 'show', ':' + name, stdout=f)
+    output = system('pep8', '--show-source', '--max-line-length=120', '.', cwd=tempdir)
+    shutil.rmtree(tempdir)
+    if output:
+        print output,
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ cryptography
 ipython
 nose >= 1.3
 mock
+pep8
 worq


### PR DESCRIPTION
* It can be installed by running `ln -sf ../../hooks/pre-commit .git/hooks/`
* Need to run `pip install pep8` or `pip install -e .` again after this lands.