### PR TITLE
Support for testing package files and build trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Results of the regression scans are published in HTML format here:
 * Diffs the results and presents potential regressions in an report for further diagnosis.
 * Does performance regression testing.
 * Extracts SSL state information.
+* Can also use local Firefox build trees or package files for testing.
 * Can maintain an updated list of HTTPS-enabled top sites.
 * Requires a highly reliable network link. **WiFi will give unstable results.**
 
@@ -144,7 +145,7 @@ take care of updates yourself.
 ### Command line arguments
 Argument | Choices / **default** | Description
 ----------|----------|----------
--b --base | **release**, nightly, beta, aurora, esr | Baseline test candidate to test against. Only used by comparative test modes.
+-b --base | **release**, nightly, beta, aurora, esr, *build tree*, *package file* | Baseline test candidate to test against. Only used by comparative test modes.
 -d --debug | | Enable verbose debug logging to the terminal
 -f --filter | 0, **1** | The default filter level 1 removes network timeouts from reports which may appear spuriously. Filter level 0 applies no filtering.
 -h --help | | Longer usage information
@@ -155,7 +156,7 @@ Argument | Choices / **default** | Description
 -o --onecrl | **production**, stage, custom | OneCRL revocation list to install to the test profiles. `custom` uses a pre-configured, static list.
 -r --reportdir | **$PWD** | Directory for report output. Default is the current directory. Each report is written to a subdirectory there by date and time. Writing to TLS Canary's Python module directory is prohibited.
 -s --source | **top**, list, ... | Set of hosts to run the test against. Pass `list` to get info on available test sets.
--t --test | release, **nightly**, beta, aurora, esr | Specify the main test candidate. Used by every run mode.
+-t --test | release, **nightly**, beta, aurora, esr, *build tree*, *package file* | Specify the main test candidate. Used by every run mode.
 -w --workdir | **~/.tlscanary** | Directory where cached files and other state is stored
 -x --scans | 3 | Number of scans to run against each host during performance mode. Currently limited to 20.
 MODE | performance, regression, scan, srcupdate | Test mode to run, given as positional parameter. This is a mandatory argument.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = 'tlscanary'
-PACKAGE_VERSION = '3.1.0a16'
+PACKAGE_VERSION = '3.1.0a17'
 
 INSTALL_REQUIRES = [
     'coloredlogs',

--- a/tlscanary/firefox_downloader.py
+++ b/tlscanary/firefox_downloader.py
@@ -114,7 +114,10 @@ class FirefoxDownloader(object):
         # We internally use slightly different platform naming, so translate
         # internal platform name to the platform name used in download URL.
         download_platform = FirefoxDownloader.__platforms[platform]['platform']
-        return FirefoxDownloader.build_urls[build].format(platform=download_platform)
+        if build in FirefoxDownloader.build_urls:
+            return FirefoxDownloader.build_urls[build].format(platform=download_platform)
+        else:
+            return None
 
     def __init__(self, workdir, cache_timeout=24*60*60):
         self.__workdir = workdir

--- a/tlscanary/main.py
+++ b/tlscanary/main.py
@@ -41,8 +41,8 @@ def get_argparser():
     parser = argparse.ArgumentParser(prog="tlscanary")
     parser.add_argument('--version', action='version', version='%(prog)s ' + pkg_version)
     parser.add_argument('-b', '--base',
-                        help='Firefox base version to compare against (default: `%s`)' % base_default,
-                        choices=release_choice,
+                        help=('Firefox base version to compare against. It can be one of {%s}, a package file, '
+                              'or a build directory (default: `%s`)') % (",".join(release_choice), base_default),
                         action='store',
                         default=base_default)
     parser.add_argument('-d', '--debug',
@@ -106,8 +106,8 @@ def get_argparser():
                         action='store',
                         default=testset_default)
     parser.add_argument('-t', '--test',
-                        help='Firefox version to test (default: `%s`)' % test_default,
-                        choices=release_choice,
+                        help=('Firefox version to test. It can be one of {%s}, a package file, '
+                              'or a build directory (default: `%s`)') % (",".join(release_choice), test_default),
                         action='store',
                         default=test_default)
     parser.add_argument('-w', '--workdir',


### PR DESCRIPTION
This adds support for passing the path to local build directories and package files for the `--base` and `--test` command line arguments.

The PR is still tentative because cloning and building *mozilla-central* for testing on Linux is still ongoing. Looks like my Linux laptop will be taking a few hours for that. If anyone here has local Linux build tree around, feel free to test this branch and report the results.

This is adressing #92.