### PR TITLE
Setting hosts limit default to 100k

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Argument | Choices / **default** | Description
 -f --filter | 0, **1** | The default filter level 1 removes network timeouts from reports which may appear spuriously. Filter level 0 applies no filtering.
 -h --help | | Longer usage information
 -j --parallel | 4 | Number of parallel firefox worker instances the host set will be distributed among
--l --limit | | The number of hosts in the test set is limited to the given number. The default is to scan all the hosts in the set.
+-l --limit | 100000 | The number of hosts in the test set is limited to the given number. Default is 100000 hosts. You can increase the limit, but such runs will require LOTS of memory (90 GBytes and more) and can cause instability.
 -m --timeout | 10 | Request timeout in seconds. Running more requests in parallel increases network latency and results in more timeouts.
 -n --requestsperworker | 50 | Chunk size of hosts that a worker will query in parallel.
 -o --onecrl | **production**, stage, custom | OneCRL revocation list to install to the test profiles. `custom` uses a pre-configured, static list.

--- a/tlscanary/modes/basemode.py
+++ b/tlscanary/modes/basemode.py
@@ -93,7 +93,7 @@ class BaseMode(object):
                            help="Limit for number of hosts to test (default: no limit)",
                            type=int,
                            action="store",
-                           default=None)
+                           default=100000)
 
         group = parser.add_argument_group("worker configuration")
         group.add_argument("-j", "--parallel",

--- a/tlscanary/modes/performance.py
+++ b/tlscanary/modes/performance.py
@@ -36,8 +36,8 @@ class PerformanceMode(RegressionMode):
         # because 1000 URIs x 20 scans per URI x 2 builds is a lot of data
         # will investigate upper limit later
         if self.args.limit > 1000:
-            logger.critical("Limiting performance test to 1000 URIs for now")
-            sys.exit(1)
+            logger.warning("Limiting performance tests to 1000 hosts.")
+            self.args.limit = 1000
         if self.args.scans > 20:
             logger.critical("Limiting performance test to 20 scans per URI list for now")
             sys.exit(1)


### PR DESCRIPTION
This implements #99, a temporary workaround addressing #44.