### PR TITLE
Pinning OneCRL-Tools to a known-working commit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = 'tlscanary'
-PACKAGE_VERSION = '3.1.0'
+PACKAGE_VERSION = '3.1.1'
 
 INSTALL_REQUIRES = [
     'coloredlogs',

--- a/tlscanary/modes/basemode.py
+++ b/tlscanary/modes/basemode.py
@@ -68,6 +68,10 @@ class BaseMode(object):
                            choices=["production", "stage", "custom"],
                            action="store",
                            default="production")
+        group.add_argument("--onecrlpin",
+                           help="OneCRL-Tools git commit to use (default: 244e704)",
+                           action="store",
+                           default="244e704")
         group.add_argument("-p", "--prefs",
                            help="Prefs to apply to all builds",
                            type=str,
@@ -228,7 +232,7 @@ class BaseMode(object):
         logger.info("Updating OneCRL revocation data")
         if one_crl_env == "production" or one_crl_env == "stage":
             # overwrite revocations file in test profile with live OneCRL entries from requested environment
-            revocations_file = one_crl.get_list(one_crl_env, self.args.workdir)
+            revocations_file = one_crl.get_list(one_crl_env, self.args.workdir, self.args.onecrlpin)
             profile_file = os.path.join(new_profile_dir, "revocations.txt")
             logger.debug("Writing OneCRL revocations data to `%s`" % profile_file)
             shutil.copyfile(revocations_file, profile_file)

--- a/tlscanary/modes/performance.py
+++ b/tlscanary/modes/performance.py
@@ -9,7 +9,6 @@ import sys
 
 from regression import RegressionMode
 import tlscanary.runlog as rl
-import tlscanary.report as report
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
* Adding the `--onecrlpin` argument for pinning OneCRL-Tools, defaulting to the last known-working commit
* Internally checking out that commit before running the `go install` command
* Bumping version to 3.1.1