### PR TITLE
WIP: rewrite performance mode

### DIFF
--- a/tlscanary/modes/performance.py
+++ b/tlscanary/modes/performance.py
@@ -76,6 +76,7 @@ class PerformanceMode(RegressionMode):
 
         argv = self.args
         test_build = self.args.test
+        base_build = self.args.base
         self.temp_hosts = []
 
         initialize = True
@@ -105,13 +106,17 @@ class PerformanceMode(RegressionMode):
                     self.temp_hosts[i]["connection_speeds_base"] = []
                     initialize = False
 
-            self.process_scan(argv, "connection_speeds")
+            #self.process_scan(argv, "connection_speeds")
 
-            argv.test = "release"
+            argv.test = base_build
             s = ScanMode(argv, self.module_dir, self.tmp_dir)
             s.setup()
             s.run()
+            #self.process_scan(argv, "connection_speeds_base")
+
+        for perf_scan in xrange(0, argv.scans):
             self.process_scan(argv, "connection_speeds_base")
+            self.process_scan(argv, "connection_speeds")
 
         # Sort sample arrays and extract average, median
         for i in xrange(0, argv.limit):

--- a/tlscanary/modes/performance.py
+++ b/tlscanary/modes/performance.py
@@ -9,21 +9,26 @@ import mock
 import pkg_resources as pkgr
 import sys
 import StringIO
-
-
-from regression import RegressionMode
 import tlscanary.runlog as rl
 
-from scan import ScanMode
 from log import LogMode
+from regression import RegressionMode
+from scan import ScanMode
 
 logger = logging.getLogger(__name__)
 
 
 class PerformanceMode(RegressionMode):
 
+    # TODO:
+    # - revisit argument validation and limits
+    # - create custom arguments object instead of passing around default
+    # - should 'connection_speeds' be renamed 'connection_speeds_test'?
+    # - review logging, enhance where needed
+    # - test large values on AWS
+
     name = "performance"
-    help = "Run a performance regression test on two Firefox versions"
+    help = "Run a performance regression test on two Firefox builds"
 
     def __init__(self, args, module_dir, tmp_dir):
         global logger
@@ -31,9 +36,8 @@ class PerformanceMode(RegressionMode):
         super(PerformanceMode, self).__init__(args, module_dir, tmp_dir)
         # Define instance attributes for later use
         self.start_time = None
-        self.test_uri_set = None
-        self.base_uri_set = None
         self.total_change = None
+        self.temp_hosts = None
 
     def setup(self):
         # Additional argument validation for hard-coded limits,
@@ -42,75 +46,14 @@ class PerformanceMode(RegressionMode):
         if self.args.limit > 1000:
             logger.warning("Limiting performance tests to 1000 hosts.")
             self.args.limit = 1000
-        if self.args.scans > 20:
-            logger.critical("Limiting performance test to 20 scans per URI list for now")
+        if self.args.scans > 50:
+            logger.critical("Limiting performance test to 50 scans per URI list for now")
             sys.exit(1)
         super(PerformanceMode, self).setup()
 
-    def getKey(host):
-        return host["rank"]
-
-
     def run(self):
-        argv = self.args
-        temp_log = {}
-        temp_log["data"] = []
-        initialize = True
 
-        # should do scans for both builds
-        for i in xrange(0,argv.scans):
-            argv.test = "release"
-            s = ScanMode(argv, self.module_dir, self.tmp_dir)
-            s.setup()
-            s.run()
-
-        # read the data back in and analyze it
-        for scan_log in xrange(0,argv.scans):
-
-            with mock.patch('sys.stdout', new=StringIO.StringIO()) as mock_stdout:
-                argv.action = "json"
-                argv.include = ['1']
-                argv.exclude = []
-                scan_run = LogMode(argv, self.module_dir, self.tmp_dir)
-                scan_run.setup()
-                scan_run.run()
-                stdout = mock_stdout.getvalue()
-            current_log = json.loads(stdout)[0]
-            host_list = sorted(current_log["data"], key=lambda x: x["rank"])
-
-            if current_log["meta"]["args"]["test"] != "release":
-                speed_sample_array_name = "connection_speeds"
-            else:
-                speed_sample_array_name = "connection_speeds_release"
-
-            if (initialize):
-                temp_log["data"] = host_list
-                temp_log["meta"] = current_log["meta"]
-                for i in xrange(0, argv.limit):
-                    temp_log["data"][i][speed_sample_array_name] = []
-                    initialize = False
-
-            for j in xrange(0, argv.limit):
-                temp_log["data"][j][speed_sample_array_name].append(
-                    host_list[j]["response"]["response_time"] - host_list[j]["response"]["command_time"]
-                )
-            # Now remove last log
-            argv.action="delete"
-            argv.really=True
-            argv.include = ['1']
-            argv.exclude = []
-            log_delete = LogMode(argv, self.module_dir, self.tmp_dir)
-            log_delete.setup()
-            log_delete.run()
-
-        logging.info(temp_log["data"][0]["host"])
-        logging.info(temp_log["data"][0]["connection_speeds_release"])
-
-
-
-
-    def run2(self):
-        # Perform the scan
+        # why do we need this? not used anywhere AFAICT
         self.start_time = datetime.datetime.now()
 
         meta = {
@@ -127,80 +70,143 @@ class PerformanceMode(RegressionMode):
         log = rldb.new_log()
         log.start(meta=meta)
 
-        test_uri_sets = []
-        base_uri_sets = []
+        # TODO:
+        # construct a custom run_args object that will be
+        # passed to each test mode, instead of just reusing ours
 
-        self.total_change = 0
-        test_speed_aggregate = 0
-        base_speed_aggregate = 0
+        argv = self.args
+        test_build = self.args.test
+        self.temp_hosts = []
 
-        for i in xrange(0, self.args.scans):
-            test_uri_sets.append(self.run_test(self.test_app, self.url_set, profile=self.test_profile,
-                                               prefs=self.args.prefs_test, get_info=True, get_certs=True,
-                                               progress=True, return_only_errors=False))
+        initialize = True
+        test_aggregate = 0
+        base_aggregate = 0
 
-            base_uri_sets.append(self.run_test(self.base_app, self.url_set, profile=self.base_profile,
-                                               prefs=self.args.prefs_base, get_info=True, get_certs=True,
-                                               progress=True, return_only_errors=False))
+        # Scans for both builds are interleaved,
+        # to try to reduce biased results caused by
+        # changing network conditions
+        for perf_scan in xrange(0, argv.scans):
+            logging.info("Starting performance scan %s out of %s" % (perf_scan+1, argv.scans))
 
-        # extract connection speed from all scans
-        test_connections_all = []
-        for uri_set in test_uri_sets:
-            test_connections_all.append(self.extract_connection_speed(uri_set))
+            argv.test = test_build
+            s = ScanMode(argv, self.module_dir, self.tmp_dir)
+            s.setup()
+            s.run()
 
-        base_connections_all = []
-        for uri_set in base_uri_sets:
-            base_connections_all.append(self.extract_connection_speed(uri_set))
+            # After the very first scan run, we want to capture
+            # that and use it as our base log, in which
+            # we will also hold our speed samples
+            if initialize:
+                base_log = self.get_log_to_json(argv)
+                base_host_list = sorted(base_log["data"], key=lambda x: x["rank"])
+                self.temp_hosts = base_host_list
+                for i in xrange(0, argv.limit):
+                    self.temp_hosts[i]["connection_speeds"] = []
+                    self.temp_hosts[i]["connection_speeds_base"] = []
+                    initialize = False
 
-        # collapse all scan data into one URI set
-        self.consolidate_connection_speed_info(test_uri_sets[0], test_connections_all)
-        self.consolidate_connection_speed_info(base_uri_sets[0], base_connections_all)
+            self.process_scan(argv, "connection_speeds")
 
-        # the first URI set becomes our primary set
-        self.test_uri_set = test_uri_sets[0]
-        self.base_uri_set = base_uri_sets[0]
+            argv.test = "release"
+            s = ScanMode(argv, self.module_dir, self.tmp_dir)
+            s.setup()
+            s.run()
+            self.process_scan(argv, "connection_speeds_base")
 
-        # new values to be inserted into response
-        for test_record in self.test_uri_set:
-            base_record = [d for d in self.base_uri_set if d[1] == test_record[1]][0]
-            test_response_time = float(test_record[2].response.connection_speed_average)
-            base_response_time = float(base_record[2].response.connection_speed_average)
-            test_speed_aggregate += test_response_time
-            base_speed_aggregate += base_response_time
-            pct_change = float((test_response_time - base_response_time) / base_response_time) * 100
-            test_record[2].response.connection_speed_change = int(pct_change)
-            # save the speed samples of the base record to the test record for now,
-            # in case we decide we want to include this in the report later
-            test_record[2].response.connection_speed_base_samples = base_record[2].response.connection_speed_samples
+        # Sort sample arrays and extract average, median
+        for i in xrange(0, argv.limit):
+            current_host = self.temp_hosts[i]
+            test_average = self.calculate_average_speed(current_host["connection_speeds"])
+            base_average = self.calculate_average_speed(current_host["connection_speeds_base"])
+            current_host["connection_speed_change_average"] = self.calculate_speed_change(test_average, base_average)
 
-        self.total_change = float((test_speed_aggregate - base_speed_aggregate) / base_speed_aggregate) * 100
+            test_aggregate += test_average
+            base_aggregate += base_average
 
-        for rank, host, result in self.test_uri_set:
-            log.log(result.as_dict())
+            test_median = self.calculate_median_speed(current_host["connection_speeds"])
+            base_median = self.calculate_median_speed(current_host["connection_speeds_base"])
+            current_host["connection_speed_change_median"] = self.calculate_speed_change(test_median, base_median)
+
+        # Tally overall performance of test vs release
+        self.total_change = self.calculate_speed_change(test_aggregate, base_aggregate)
+
+        for result in self.temp_hosts:
+            log.log(result)
 
         meta["run_finish_time"] = datetime.datetime.utcnow().isoformat()
-        meta["total_change"] = self.total_change
+        meta["performance_change"] = self.total_change
         self.save_profile(self.test_profile, "test_profile", log)
         self.save_profile(self.base_profile, "base_profile", log)
         log.stop(meta=meta)
 
-    @staticmethod
-    def extract_connection_speed(uri_set):
-        new_set = []
-        for record in uri_set:
-            new_set.append([
-                record[0],  # URI rank
-                record[2].response.response_time - record[2].response.command_time  # connection speed
-            ])
-        return new_set
+        # this will go away post-development
+        self.temp_debug_output()
 
-    def consolidate_connection_speed_info(self, uri_set, connection_sets):
-        for record in uri_set:
-            temp_speeds = []
-            speed_aggregate = 0
-            for connection_set in connection_sets:
-                speed = [d for d in connection_set if d[0] == record[0]][0][1]
-                speed_aggregate += speed
-                temp_speeds.append(speed)
-            record[2].response.connection_speed_average = speed_aggregate / self.args.scans
-            record[2].response.connection_speed_samples = str(temp_speeds).strip('[]')
+    # temporary debugging function
+    def temp_debug_output(self):
+        logging.info("Total change: %s" % self.total_change)
+        for i in xrange (0,3):
+            logging.info("Host: %s " % self.temp_hosts[i]["host"])
+            logging.info("Average change: %s " % self.temp_hosts[i]["connection_speed_change_average"])
+            logging.info("Median change: %s " % self.temp_hosts[i]["connection_speed_change_median"])
+            logging.info(self.temp_hosts[i]["connection_speeds"])
+            logging.info(self.temp_hosts[i]["connection_speeds_base"])
+
+    @staticmethod
+    def calculate_average_speed(sample_list):
+        num_samples = len(sample_list)
+        running_total = 0
+        for i in xrange(0, num_samples):
+            running_total += sample_list[i]
+        return float(running_total / num_samples)
+
+    @staticmethod
+    def calculate_median_speed(sample_list):
+        sample_list.sort()
+        num_samples = len(sample_list)
+        middle = num_samples/2
+        if num_samples % 2 == 1:
+            median = sample_list[middle]
+        else:
+            median = (sample_list[middle] + sample_list[middle-1]) / 2
+        return float(median)
+
+    @staticmethod
+    def calculate_speed_change(a, b):
+        change = (float(a - b) / b) * 100
+        format_to_two_decimals = float('%.2f' % change)
+        return format_to_two_decimals
+
+    def delete_last_log(self):
+        argv = self.args
+        argv.action = "delete"
+        argv.really = True
+        argv.include = ['1']
+        argv.exclude = []
+        log_delete = LogMode(argv, self.module_dir, self.tmp_dir)
+        log_delete.setup()
+        log_delete.run()
+
+    def extract_connection_speed(self, host_list, array_name):
+        for j in xrange(0, self.args.limit):
+            connection_speed = host_list[j]["response"]["response_time"] - host_list[j]["response"]["command_time"]
+            self.temp_hosts[j][array_name].append(
+                connection_speed
+            )
+
+    def get_log_to_json(self, argv):
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as mock_stdout:
+            argv.action = "json"
+            argv.include = ['1']
+            argv.exclude = []
+            scan_run = LogMode(argv, self.module_dir, self.tmp_dir)
+            scan_run.setup()
+            scan_run.run()
+            stdout = mock_stdout.getvalue()
+        return json.loads(stdout)[0]
+
+    def process_scan(self, argv, array_name):
+        current_log = self.get_log_to_json(argv)
+        host_list = sorted(current_log["data"], key=lambda x: x["rank"])
+        self.extract_connection_speed(host_list, array_name)
+        self.delete_last_log()


### PR DESCRIPTION
This is a total rewrite, to take advantage of run logging and composition of other modes.

I would like your general feedback. Also, please try with these parameters:

```
tlscanary performance -l 5 -x 3 
tlscanary performance -l 5 -x 10
tlscanary performance -l 5 -x 30
tlscanary performance -l 5 -x 10 -t release
tlscanary performance -l 5 -x 30 -t release
tlscanary performance -l 100 -x 5
tlscanary performance -l 100 -x 20
tlscanary performance -l 1000 -x 10 -t release
```

When we pass in the test build as `release`, we are theoretically testing the validity of the performance mode itself. We shouldn't see too much variation if we are comparing scans of the same build.

Also, increasing the number of scans (`-x`) gives us more samples and hopefully more accurate results, since we'd like to filter out any temporary glitches in network or local machine performance.

I'd like to see what you find, but I have run into some real oddness.
* Host limits of <20 seem to work well, and run with large amounts of scans (>20) we start to see something useful. The test of release vs release tends to indicate 0-2% speed difference, usually, which is an acceptable margin of error, I think. 
* Things get interesting testing nightly vs release, because we are seeing a consistent performance increase of ~10%. That varies, but nightly definitely seems faster.
* A limit of 100 hosts already starts to show progressive slowdowns with each scan. I think the tool introduces network congestion and/or memory issues that start to affect the accuracy of the test mode. This is even more pronounced with 1000 hosts and 10 scans. This means that right now, this mode is quite limited.  

Still, as a validation for a check-in, a performance pass of the top 20 sites might yield a reasonable assurance that nothing is super broken, and this could have caught performance regressions of the past.

Another strategy for performance testing is to allow the user to do their own scans one at a time, and just analyze the JSON output with their own methodology. This eliminates the overhead of the canary, but I was hoping to make this easy.


