### PR TITLE
WIP: Moving to socket-based XPCShell worker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,12 @@
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = 'tlscanary'
-PACKAGE_VERSION = '3.2.0'
+PACKAGE_VERSION = '3.2.0a2'
 
 INSTALL_REQUIRES = [
     'coloredlogs',
     'cryptography',
+    'eventlet',
     'hashfs',
     'python-dateutil',
     'worq'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,11 +3,13 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
+import os
 import shutil
 import tempfile
 
 import tlscanary.firefox_downloader as fd
 import tlscanary.firefox_extractor as fe
+import tlscanary.firefox_app as fa
 
 # Silence logging
 logging.disable(logging.INFO)
@@ -31,6 +33,8 @@ tmp_dir = None
 def test_firefox_download_dummy():
     """Downloading firefox instance for tests"""
     global test_app, test_archive
+    # test_app = fa.FirefoxApp("/tmp/firefox-nightly_osx/")
+    # return
     # Get ourselves a Firefox app for the local platform.
     fdl = fd.FirefoxDownloader(tmp_dir)
     test_archive = fdl.download("nightly", use_cache=True)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,8 +33,8 @@ tmp_dir = None
 def test_firefox_download_dummy():
     """Downloading firefox instance for tests"""
     global test_app, test_archive
-    # test_app = fa.FirefoxApp("/tmp/firefox-nightly_osx/")
-    # return
+    test_app = fa.FirefoxApp("/tmp/firefox-nightly_osx/")
+    return
     # Get ourselves a Firefox app for the local platform.
     fdl = fd.FirefoxDownloader(tmp_dir)
     test_archive = fdl.download("nightly", use_cache=True)

--- a/tests/xpcshell_worker_test.py
+++ b/tests/xpcshell_worker_test.py
@@ -2,53 +2,229 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import mock
 from nose import SkipTest
 from nose.tools import *
-from time import sleep
+import socket
+import time
 
 import tests
 import tlscanary.xpcshell_worker as xw
 
 
-@mock.patch('sys.stdout')  # to silence progress bar
-def test_xpcshell_worker(mock_sys):
+foxes = None
+
+
+def set_fox_trap():
+    """Refresh the global fox registry"""
+    global foxes
+    foxes = []
+
+
+def kill_stray_foxes():
+    """Ensure that there are no stray foxes leaking into the environment"""
+    global foxes
+    for fox in foxes:
+        if fox.worker_process is None:
+            # Worker was never spawned
+            continue
+        try:
+            fox.kill()
+        except OSError:
+            # already killed
+            pass
+
+
+def new_worker(*args, **kwargs):
+    """Return worker instance that is registered with the global foxes registry"""
+    global foxes
+    fox = xw.XPCShellWorker(*args, **kwargs)
+    foxes.append(fox)
+    return fox
+
+
+@with_setup(set_fox_trap, kill_stray_foxes)
+def test_xpcshell_worker():
     """XPCShell worker runs and is responsive"""
 
     # Skip test if there is no app for this platform
     if tests.test_app is None:
         raise SkipTest("XPCShell worker can not be tested on this platform")
 
-    # Spawn a worker.
-    w = xw.XPCShellWorker(tests.test_app)
-    w.spawn()
-    assert_true(w.is_running())
+    # Spawn a worker
+    worker_one = new_worker(tests.test_app)
+    assert_false(worker_one.is_running(), "XPCShell worker must explicitly be started")
+    assert_false(worker_one.helpers_running(), "worker helpers don't run unless explicitly started")
+    assert_true(worker_one.ask(xw.Command("info"), timeout=1) is None, "stopped worker yields None responses")
+    worker_one.spawn()
+    assert_true(worker_one.is_running(), "XPCShell worker starts up fine")
+    assert_true(worker_one.helpers_running(), "worker helpers are running")
 
-    # Send commands
-    w.send(xw.Command("info", id=1))
-    w.send(xw.Command("quit", id=2))
+    # Open connection to worker
+    conn = worker_one.get_connection(timeout=5)
+    assert_true(worker_one.port is not None, "XPCShell worker reports listening on a port")
 
-    # We need to wait until the reader thread is guaranteed to have run.
-    sleep(1)
+    # Send info command and check result
+    res = conn.ask(xw.Command("info"))
+    assert_true(res is not None, "info command can be sent")
+    assert_true(type(res) is xw.Response, "worker connection returns Response objects")
+    assert_true(res.is_success(), "info command is acknowledged with success")
+    assert_equal(res.worker_id, worker_one.id, "worker Python ID matches JS ID")
+    assert_true("appConstants" in res.result, "info response contains `appConstants`")
+    assert_equal(res.result["appConstants"]["MOZ_UPDATE_CHANNEL"], "nightly",
+                 "info response has expected value")
 
-    # Unfetched results should stay queued even after the worker terminated.
-    w.terminate()
+    # Send invalid commands and check for negative ACKs
+    res = conn.ask(xw.Command("bogus"))
+    assert_false(res.is_success(), "bogus command is acknowledged with failure")
+    res = conn.ask("""{"mode":"scan"}""")  # missing mandatory argument
+    assert_false(res.is_success(), "incomplete command is acknowledged with failure")
+    res = conn.ask("""{"mode":"info",broken}""")  # defective JSON
+    assert_false(res.is_success(), "broken command is acknowledged with failure")
+    res = conn.ask("")  # empty line
+    assert_false(res.is_success(), "empty line command is acknowledged with failure")
 
-    # Get the results
-    responses = w.receive()
+    # Spawn a second worker
+    worker_two = new_worker(tests.test_app)
+    worker_two.spawn()
+    assert_true(worker_two.is_running(), "second XPCShell worker starts up fine")
+    assert_true(worker_two.helpers_running(), "second worker's helpers are running")
 
-    assert_equal(len(responses), 2, "XPCShell worker delivers expected number of responses")
-    assert_true(type(responses[0]) is xw.Response, "XPCShell worker delivers valid 1st response")
-    assert_true(type(responses[1]) is xw.Response, "XPCShell worker delivers valid 2nd response")
+    # Open connection to second worker
+    conn_two = xw.WorkerConnection(worker_two.port, timeout=5)
+    assert_true(worker_one.id != worker_two.id, "workers have different IDs")
+    assert_true(conn.port != conn_two.port, "workers listening on different ports")
 
-    info_response, quit_response = responses
+    # Send info command to second worker check result
+    res = conn_two.ask(xw.Command("info"))
+    assert_true(res is not None, "info command can be sent to second worker")
+    assert_true(res.is_success(), "info command is acknowledged with success by second worker")
+    assert_true(res.worker_id != worker_one.id, "response does not come from first worker")
+    assert_true("appConstants" in res.result, "info response from second worker contains `appConstants`")
 
-    assert_equal(info_response.id, 1, "Info response has expected ID")
-    assert_true(info_response.success, "Info command was successful")
-    assert_true("appConstants" in info_response.result, "Info response contains `appConstants`")
-    assert_true("nssInfo" in info_response.result, "Info response contains `nssInfo`")
-    assert_equal(info_response.result["appConstants"]["MOZ_UPDATE_CHANNEL"], "nightly",
-                 "Info response has expected value")
+    # Send info command to first worker again and check result
+    res = conn_two.ask(xw.Command("info"))
+    assert_true(res is not None, "info command can be sent again")
+    assert_true(res.is_success(), "info command is acknowledged with success again")
+    assert_true("appConstants" in res.result, "info response contains `appConstants` again")
 
-    assert_equal(quit_response.id, 2, "Quit response has expected ID")
-    assert_true(info_response.success, "Quit command was successful")
+    # Check whether worker exits cleanly
+    assert_true(worker_one.is_running(), "first worker is still alive")
+    assert_true(worker_one.helpers_running(), "first worker's helpers are still alive")
+    res = worker_one.quit()
+    assert_true(res is not None, "quit command can be sent")
+    assert_true(res.is_success(), "quit command is acknowledged with success")
+    time.sleep(0.05)
+    assert_false(worker_one.is_running(), "first worker terminates after quit command")
+    assert_false(worker_one.helpers_running(), "helpers are not persisting")
+
+    # Quit second worker "the unfriendly way"
+    assert_true(worker_two.is_running(), "second worker is still alive")
+    assert_true(worker_two.helpers_running(), "second worker's helpers are still alive")
+    worker_two.terminate()
+    time.sleep(0.05)
+    assert_false(worker_two.is_running(), "second worker terminates")
+    assert_false(worker_two.helpers_running(), "second worker's helpers are not persisting")
+
+
+@with_setup(set_fox_trap, kill_stray_foxes)
+def test_xpcshell_worker_load():
+    """XPCShell worker can take load"""
+
+    # Skip test if there is no app for this platform
+    if tests.test_app is None:
+        raise SkipTest("XPCShell worker load can not be tested on this platform")
+
+    # Spawn a worker
+    worker = new_worker(tests.test_app)
+    worker.spawn()
+    assert_true(worker.is_running() and worker.helpers_running(), "XPCShell worker running for load test")
+
+    conn = worker.get_connection(timeout=5)
+    results = []
+    timeout_time = time.time() + 5
+    while time.time() < timeout_time:
+        results.append(conn.ask(xw.Command("info")))
+
+    had_failed_requests = False
+    for result in results:
+        if result is None:
+            had_failed_requests = True
+            break
+    assert_false(had_failed_requests, "no failed requests during load test")
+
+    worker.quit()
+
+    print " Gathered %d results in 5 seconds " % len(results),
+
+
+@with_setup(set_fox_trap, kill_stray_foxes)
+def test_xpcshell_worker_timeout():
+    """XPCShell worker has proper timeout behavior"""
+
+    # Skip test if there is no app for this platform
+    if tests.test_app is None:
+        raise SkipTest("XPCShell worker timeouts can not be tested on this platform")
+
+    # Spawn a worker
+    worker = new_worker(tests.test_app)
+    worker.spawn()
+    assert_true(worker.is_running() and worker.helpers_running(), "XPCShell worker running for timeout test")
+
+    res = worker.ask(xw.Command("test", sleep=0.05), timeout=0.1)
+    assert_true(type(res) is xw.Response, "test command yields Response object")
+
+    with assert_raises(socket.timeout):  # "long response delays trigger timeouts"
+        worker.ask(xw.Command("test", sleep=0.05), timeout=0.01)
+
+    assert_true(worker.is_running(), "worker still running after timeout")
+    assert_true(worker.ask(xw.Command("info"), timeout=0.1) is not None, "worker still responsive after timeout")
+
+    worker.quit()
+
+
+@with_setup(set_fox_trap, kill_stray_foxes)
+def test_xpcshell_worker_scan_command():
+    """XPCShell worker can scan hosts"""
+
+    # Skip test if there is no app for this platform
+    if tests.test_app is None:
+        raise SkipTest("XPCShell worker scans not be tested on this platform")
+
+    # Spawn a worker
+    worker = new_worker(tests.test_app)
+    worker.spawn()
+    assert_true(worker.is_running() and worker.helpers_running(), "XPCShell worker running for scan test")
+
+    # Scans bail on first redirect, thus redirecting hosts come
+    # through the error handler and are marked non-successful.
+    redirecting_host = "www.mozilla.org"
+
+    # Non-redirecting scans come through the load handler
+    # This test will fail once twitter.com changes its redirecting behavior.
+    direct_host = "twitter.com"
+
+    res_a = worker.ask(xw.Command("scan", host=redirecting_host, timeout=10), timeout=12)
+    res_b = worker.ask(xw.Command("scan", host=redirecting_host, timeout=0.001), timeout=1)
+    res_c = worker.ask(xw.Command("scan", host=direct_host, include_certificates=True, timeout=10), timeout=12)
+
+    worker.quit()
+
+    assert_true(type(res_a) is xw.Response, "first scan command yields Response object")
+    assert_false(res_a.is_success(), "first command fails as expected due to redirect")
+    assert_equal(res_a.result["origin"], "error_handler", "first scan comes through error handler")
+    assert_equal(res_a.result["info"]["status"], 0, "first scan has no error status")
+    assert_true(res_a.result["info"]["certificate_chain_length"] == 0, "first response includes no certificates")
+    assert_true(res_a.result["info"]["certificate_chain"] is None, "first response has no certificate data")
+
+    assert_true(type(res_b) is xw.Response, "second scan command yields Response object")
+    assert_false(res_b.is_success(), "second command fails as expected due to timeout")
+    assert_equal(res_b.result["info"]["status"], 0x804B0002, "second scan has NS_BINDING_ABORTED status")
+    assert_equal(res_b.result["origin"], "timeout_handler", "second scan was timeout")
+
+    assert_true(type(res_c) is xw.Response, "third scan command yields Response object")
+    assert_true(res_c.is_success(), "third command was successful")
+    assert_equal(res_c.result["info"]["status"], 0, "third scan has no TSL error")
+    assert_equal(res_c.result["origin"], "load_handler", "third scan is fully loaded")
+    assert_true(res_c.result["info"]["certificate_chain_length"] > 0, "third response includes certificates")
+    assert_equal(res_c.result["info"]["certificate_chain_length"],
+                 len(res_c.result["info"]["certificate_chain"]), "third response has certificate data")

--- a/tests/xpcshell_worker_test.py
+++ b/tests/xpcshell_worker_test.py
@@ -156,7 +156,7 @@ def test_xpcshell_worker_load():
 
     worker.quit()
 
-    print "  Gathered %d results in 5 seconds" % len(results),
+    print " Gathered %d results in 5 seconds... " % len(results),
 
 
 @with_setup(set_fox_trap, kill_stray_foxes)
@@ -238,19 +238,19 @@ def test_xpcshell_worker_parallel():
         delay = random.random() * 0.9 + 0.1
         conn.send(xw.Command("test", sleep=delay))
         pending.append(conn)
-        print "sent %d commands" % len(pending)
+        # print "sent %d commands" % len(pending)
 
     while len(results) < len(pending):
         readable, _, exceptions = select.select(pending, [], pending, 5)
         assert_true(len(exceptions) == 0, "select() does not yield exceptions")
         assert_false(len(readable) == 0, "select() does not timeout")
-        print "received %d results" % len(readable)
+        # print "received %d results" % len(readable)
         for conn in readable:
             res = conn.receive(timeout=2)
             assert_true(res is not None, "worker always responds")
             results.append(res)
 
-    print "received %d results" % len(results)
+    # print "received %d results" % len(results)
     assert_equal(len(results), len(pending), "worker answers all commands")
 
     worker.terminate()

--- a/tests/xpcshell_worker_test.py
+++ b/tests/xpcshell_worker_test.py
@@ -154,7 +154,7 @@ def test_xpcshell_worker_load():
 
     worker.quit()
 
-    print " Gathered %d results in 5 seconds " % len(results),
+    print "  Gathered %d results in 5 seconds" % len(results),
 
 
 @with_setup(set_fox_trap, kill_stray_foxes)

--- a/tests/xpcshell_worker_test.py
+++ b/tests/xpcshell_worker_test.py
@@ -202,7 +202,7 @@ def test_xpcshell_worker_disconnect():
     reconnect_required = conn.send(xw.Command("info"))
     assert_false(reconnect_required, "open connections are not reconnected for send")
 
-    conn.shutdown()
+    conn.close()
     res = conn.receive()
     assert_true(res is None, "receive on closed connection yields None")
 

--- a/tlscanary/js/xpcshell_worker.js
+++ b/tlscanary/js/xpcshell_worker.js
@@ -14,6 +14,7 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/NetUtil.jsm");
 Cu.import("resource://gre/modules/AppConstants.jsm");
+Cu.importGlobalProperties(["XMLHttpRequest"]);
 
 const nsINSSErrorsService = Ci.nsINSSErrorsService;
 let nssErrorsService = Cc['@mozilla.org/nss_errors_service;1'].getService(nsINSSErrorsService);
@@ -250,7 +251,7 @@ function scan_host(args, response_cb) {
         QueryInterface: XPCOMUtils.generateQI([Ci.nsIChannelEventSink])
     };
 
-    let request = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"].createInstance(Ci.nsIXMLHttpRequest);
+    let request = new XMLHttpRequest();
     try {
         request.mozBackgroundRequest = true;
         request.open("HEAD", host, true);
@@ -525,7 +526,7 @@ StreamReader.prototype = {
                 return;
             }
             if (error.result === Cr.NS_BASE_STREAM_CLOSED) {
-                print("WARNING: Base stream was closed:", error.toString());
+                print("DEBUG: Base stream was closed:", error.toString());
             } else {
                 print("ERROR: Unable to check stream availability:", error.toString());
             }

--- a/tlscanary/js/xpcshell_worker.js
+++ b/tlscanary/js/xpcshell_worker.js
@@ -410,11 +410,10 @@ Command.prototype.handle = function _handle() {
 function handle_request(request, connection) {
     print("DEBUG: Handling request:", request);
     try {
-        let cmd = new Command(request, connection);
+        const cmd = new Command(request, connection);
         cmd.handle();
     } catch (error) {
         print("ERROR: Unable to handle command:", error.toString());
-        connection.close()
     }
 }
 
@@ -439,19 +438,19 @@ const ConverterOutputStream = CC("@mozilla.org/intl/converter-output-stream;1",
                                  "init");
 
 
-let SocketListener = {
+const SocketListener = {
     onSocketAccepted(socket, transport) {
         print("DEBUG: Connection from port", transport.host, transport.port);
         try {
             transport.setTimeout(Cr.TIMEOUT_CONNECT, 60);
             transport.setTimeout(Cr.TIMEOUT_READ_WRITE, 60);
-            // let input_stream = transport.openInputStream(Cr.OPEN_UNBUFFERED | Cr.OPEN_BLOCKING, 0, 0)
-            let input_stream = transport.openInputStream(0, 0, 0)
+            // const input_stream = transport.openInputStream(Cr.OPEN_UNBUFFERED | Cr.OPEN_BLOCKING, 0, 0)
+            const input_stream = transport.openInputStream(0, 0, 0)
                 .QueryInterface(Ci.nsIAsyncInputStream);
-            // let output_stream = transport.openOutputStream(Cr.OPEN_UNBUFFERED | Cr.OPEN_BLOCKING, 0, 0);
-            let output_stream = transport.openOutputStream(0, 0, 0);
-            let connection = new Connection(socket, transport, input_stream, output_stream);
-            let reader = new StreamReader(connection);
+            // const output_stream = transport.openOutputStream(Cr.OPEN_UNBUFFERED | Cr.OPEN_BLOCKING, 0, 0);
+            const output_stream = transport.openOutputStream(0, 0, 0);
+            const connection = new Connection(socket, transport, input_stream, output_stream);
+            const reader = new StreamReader(connection);
             input_stream.asyncWait(reader, 0, 0, main_thread);
         } catch (error) {
             print("ERROR: Command listener failed handling streams:", error.toString());

--- a/tlscanary/js/xpcshell_worker.js
+++ b/tlscanary/js/xpcshell_worker.js
@@ -526,7 +526,9 @@ StreamReader.prototype = {
                 return;
             }
             if (error.result === Cr.NS_BASE_STREAM_CLOSED) {
-                print("DEBUG: Base stream was closed:", error.toString());
+                // This is thrown after every client disconnect (potentially noisy on stdio)
+                print("DEBUG: Client closed connection on port", this.connection.transport.host,
+                    this.connection.transport.port);
             } else {
                 print("ERROR: Unable to check stream availability:", error.toString());
             }

--- a/tlscanary/js/xpcshell_worker.js
+++ b/tlscanary/js/xpcshell_worker.js
@@ -6,18 +6,17 @@
 
 const {classes: Cc, interfaces: Ci, utils: Cu, results: Cr, Constructor: CC} = Components;
 
-const DEFAULT_TIMEOUT = 10000;
-const thread_manager = Cc["@mozilla.org/thread-manager;1"].getService(Ci.nsIThreadManager);
-const main_thread = thread_manager.mainThread;
-
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/NetUtil.jsm");
 Cu.import("resource://gre/modules/AppConstants.jsm");
 Cu.importGlobalProperties(["XMLHttpRequest"]);
 
+const DEFAULT_TIMEOUT = 10000;
+const thread_manager = Cc["@mozilla.org/thread-manager;1"].getService(Ci.nsIThreadManager);
+const main_thread = thread_manager.mainThread;
 const nsINSSErrorsService = Ci.nsINSSErrorsService;
-let nssErrorsService = Cc['@mozilla.org/nss_errors_service;1'].getService(nsINSSErrorsService);
+const nssErrorsService = Cc['@mozilla.org/nss_errors_service;1'].getService(nsINSSErrorsService);
 
 
 function uuid4() {
@@ -34,8 +33,9 @@ function uuid4() {
 let worker_id = uuid4();
 
 
-function set_worker_id(id) {
-    worker_id = id;
+function set_worker_id(new_id) {
+    // global: worker_id
+    worker_id = new_id;
 }
 
 
@@ -78,7 +78,7 @@ function set_prefs(prefs) {
 
 function set_profile(profile_path) {
     let file = Cc["@mozilla.org/file/local;1"]
-        .createInstance(Ci.nsILocalFile);
+        .createInstance(Ci.nsIFile);
     file.initWithPath(profile_path);
     let dir_service = Cc["@mozilla.org/file/directory_service;1"]
         .getService(Ci.nsIProperties);
@@ -409,7 +409,7 @@ Command.prototype.handle = function _handle() {
  */
 
 function handle_request(request, connection) {
-    print("DEBUG: Handling request:", request);
+    // print("DEBUG: Handling request:", request);
     try {
         const cmd = new Command(request, connection);
         cmd.handle();
@@ -576,7 +576,7 @@ StreamReader.prototype = {
         if (this.buffer[this.buffer.length - 1] === '\n') {
             // The buffer we just read may have included several command lines
             this.buffer.slice(0, -1).split('\n').forEach((function (cmd_str) {
-                print("DEBUG: handling request line:", cmd_str);
+                // print("DEBUG: handling request line:", cmd_str);
                 handle_request(cmd_str, this.connection);
             }).bind(this));
             // Clear buffer for next incoming lines

--- a/tlscanary/js/xpcshell_worker.js
+++ b/tlscanary/js/xpcshell_worker.js
@@ -1,0 +1,633 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const {classes: Cc, interfaces: Ci, utils: Cu, results: Cr, Constructor: CC} = Components;
+
+const DEFAULT_TIMEOUT = 10000;
+const thread_manager = Cc["@mozilla.org/thread-manager;1"].getService(Ci.nsIThreadManager);
+const main_thread = thread_manager.mainThread;
+
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/NetUtil.jsm");
+Cu.import("resource://gre/modules/AppConstants.jsm");
+
+const nsINSSErrorsService = Ci.nsINSSErrorsService;
+let nssErrorsService = Cc['@mozilla.org/nss_errors_service;1'].getService(nsINSSErrorsService);
+
+
+function uuid4() {
+  function rnd(bits) {
+    return Math.floor((1 + Math.random()) * 2**bits).toString(16).substring(1);
+  }
+  return `${rnd(32)}-${rnd(16)}-${rnd(16)}-${rnd(16)}-${rnd(48)}`;
+}
+
+
+// This is a global worker ID that is sent with every message to the Python world
+// It can be overridden by the `setworkerid` command. The Python world will usually
+// set this to a UUID1 string to synchronize the two worlds.
+let worker_id = uuid4();
+
+
+function set_worker_id(id) {
+    worker_id = id;
+}
+
+
+function get_runtime_info() {
+    return {
+        nssInfo: Cc["@mozilla.org/security/nssversion;1"].getService(Ci.nsINSSVersion),
+        appConstants: AppConstants
+    };
+}
+
+
+function set_prefs(prefs) {
+    for (let key in prefs) {
+        let prop = prefs[key].split(";")[0];
+        let value = prefs[key].split(";")[1];
+
+        // Pref values are passed in as strings and must be examined
+        // to determine the intended types and values.
+        let type = "string"; // default
+        if (value === "true" || value === "false") type = "boolean";
+        if (!isNaN(value)) type = "number";
+        if (value === undefined) type = "undefined";
+
+        switch (type) {
+            case "boolean":
+                Services.prefs.setBoolPref(prop, value === "true" ? 1 : 0);
+                break;
+            case "number":
+                Services.prefs.setIntPref(prop, value);
+                break;
+            case "string":
+                Services.prefs.setPref(prop, value);
+                break;
+            default:
+                throw "Unsupported pref type " + type;
+        }
+    }
+}
+
+
+function set_profile(profile_path) {
+    let file = Cc["@mozilla.org/file/local;1"]
+        .createInstance(Ci.nsILocalFile);
+    file.initWithPath(profile_path);
+    let dir_service = Cc["@mozilla.org/file/directory_service;1"]
+        .getService(Ci.nsIProperties);
+    let provider = {
+        getFile: function(prop, persistent) {
+            persistent.value = true;
+            if (prop === "ProfD" || prop === "ProfLD" || prop === "ProfDS" ||
+                prop === "ProfLDS" || prop === "PrefD" || prop === "TmpD") {
+                return file.clone();
+            }
+            return null;
+        },
+        QueryInterface: function(iid) {
+            if (iid.equals(Ci.nsIDirectoryServiceProvider) ||
+                iid.equals(Ci.nsISupports)) {
+                return this;
+            }
+            throw Cr.NS_ERROR_NO_INTERFACE;
+        }
+    };
+    dir_service.QueryInterface(Ci.nsIDirectoryService)
+        .registerProvider(provider);
+
+    // The methods of 'provider' will retain this scope so null out
+    // everything to avoid spurious leak reports.
+    profile_path = null;
+    dir_service = null;
+    provider = null;
+
+    return file.clone();
+}
+
+
+function collect_request_info(xhr, report_certs) {
+    // Much of this is documented in https://developer.mozilla.org/en-US/docs/Web/API/
+    // XMLHttpRequest/How_to_check_the_secruity_state_of_an_XMLHTTPRequest_over_SSL
+
+    let info = {};
+    info.status = xhr.channel.QueryInterface(Ci.nsIRequest).status;
+    info.original_uri = xhr.channel.originalURI.asciiSpec;
+    info.uri = xhr.channel.URI.asciiSpec;
+
+    try {
+        info.error_class = nssErrorsService.getErrorClass(info.status);
+    } catch (e) {
+        info.error_class = null;
+    }
+
+    info.security_info_status = false;
+    info.transport_security_info_status = false;
+    info.ssl_status_status = false;
+
+    // Try to query security info
+    let sec_info = xhr.channel.securityInfo;
+    if (sec_info === null) return info;
+    info.security_info_status = true;
+
+    if (sec_info instanceof Ci.nsITransportSecurityInfo) {
+        sec_info.QueryInterface(Ci.nsITransportSecurityInfo);
+        info.transport_security_info_status = true;
+        info.security_state = sec_info.securityState;
+        info.security_description = sec_info.shortSecurityDescription;
+        info.raw_error = sec_info.errorMessage;
+    }
+
+    if (sec_info instanceof Ci.nsISSLStatusProvider) {
+        info.ssl_status_status = false;
+        let ssl_status = sec_info.QueryInterface(Ci.nsISSLStatusProvider).SSLStatus;
+        if (ssl_status != null) {
+            info.ssl_status_status = true;
+            info.ssl_status = ssl_status.QueryInterface(Ci.nsISSLStatus);
+            // TODO: Find way to extract this py-side.
+            try {
+                let usages = {};
+                let usages_string = {};
+                info.ssl_status.server_cert.getUsagesString(true, usages, usages_string);
+                info.certified_usages = usages_string.value;
+            } catch (e) {
+                info.certified_usages = null;
+            }
+        }
+    }
+
+    if (info.ssl_status_status && report_certs) {
+        let server_cert = info.ssl_status.serverCert;
+        let cert_chain = [];
+        if (server_cert.sha1Fingerprint) {
+            cert_chain.push(server_cert.getRawDER({}));
+            let chain = server_cert.getChain().enumerate();
+            while (chain.hasMoreElements()) {
+                let child_cert = chain.getNext().QueryInterface(Ci.nsISupports)
+                    .QueryInterface(Ci.nsIX509Cert);
+                cert_chain.push(child_cert.getRawDER({}));
+            }
+        }
+        info.certificate_chain_length = cert_chain.length;
+        info.certificate_chain = cert_chain;
+    } else {
+        info.certificate_chain_length = 0;
+        info.certificate_chain = null;
+    }
+
+    if (info.ssl_status_status) {
+        // Some values might be missing from the connection state, for example due
+        // to a broken SSL handshake. Try to catch exceptions before report_result's
+        // JSON serializing does.
+        let sane_ssl_status = {};
+        info.ssl_status_errors = [];
+        for (let key in info.ssl_status) {
+            if (!info.ssl_status.hasOwnProperty(key)) continue;
+            try {
+                sane_ssl_status[key] = JSON.parse(JSON.stringify(info.ssl_status[key]));
+            } catch (e) {
+                sane_ssl_status[key] = null;
+                info.ssl_status_errors.push({key: e.toString()});
+            }
+        }
+        info.ssl_status = sane_ssl_status;
+    }
+
+    return info;
+}
+
+
+function scan_host(args, response_cb) {
+
+    let host = args.host;
+
+    // Prepend https:// scheme if there is no scheme defined in the host name
+    const scheme_sep = host.indexOf("://");
+    if (scheme_sep < 0 || scheme_sep > 10) host = "https://" + host;
+
+    let report_certs = args.include_certificates === true;
+
+    function load_handler(msg) {
+        if (msg.target.readyState === 4) {
+            response_cb(true, {origin: "load_handler", info: collect_request_info(msg.target, report_certs)});
+        } else {
+            response_cb(false, {origin: "load_handler", info: collect_request_info(msg.target, report_certs)});
+        }
+    }
+
+    function error_handler(msg) {
+        response_cb(false, {origin: "error_handler", info: collect_request_info(msg.target, report_certs)});
+    }
+
+    function abort_handler(msg) {
+        response_cb(false, {origin: "abort_handler", info: collect_request_info(msg.target, report_certs)});
+    }
+
+    function timeout_handler(msg) {
+        response_cb(false, {origin: "timeout_handler", info: collect_request_info(msg.target, report_certs)});
+    }
+
+    // This gets called when a redirect happens.
+    function RedirectStopper() {}
+    RedirectStopper.prototype = {
+        asyncOnChannelRedirect: function (oldChannel, newChannel, flags, callback) {
+            // This callback prevents redirects, and the request's error handler will be called.
+            callback.onRedirectVerifyCallback(Cr.NS_ERROR_ABORT);
+        },
+        getInterface: function (iid) {
+            return this.QueryInterface(iid);
+        },
+        QueryInterface: XPCOMUtils.generateQI([Ci.nsIChannelEventSink])
+    };
+
+    let request = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"].createInstance(Ci.nsIXMLHttpRequest);
+    try {
+        request.mozBackgroundRequest = true;
+        request.open("HEAD", host, true);
+        request.timeout = args.timeout ? args.timeout * 1000 : DEFAULT_TIMEOUT;
+        request.channel.loadFlags |= Ci.nsIRequest.LOAD_ANONYMOUS
+            | Ci.nsIRequest.LOAD_BYPASS_CACHE
+            | Ci.nsIRequest.INHIBIT_PERSISTENT_CACHING
+            | Ci.nsIRequest.VALIDATE_NEVER;
+        request.channel.notificationCallbacks = new RedirectStopper();
+        request.addEventListener("load", load_handler, false);
+        request.addEventListener("error", error_handler, false);
+        request.addEventListener("abort", abort_handler, false);
+        request.addEventListener("timeout", timeout_handler, false);
+        request.send(null);
+    } catch (error) {
+        // This is supposed to catch malformed host names, but could
+        // potentially mask other errors.
+        response_cb(false, {origin: "request_error", error: error.message,
+            info: collect_request_info(request, false)});
+    }
+}
+
+function do_test(args, response_cb) {
+    if (args.count_to) {
+        print("DEBUG: Counting to", args.count_to);
+        for (let x = 1; x <= args.count_to; x++) {
+            for (let y = 0; y < 100000; y += 2) { y--; }  // Just waste some time
+            if (args.count_debug) {
+                print("DEBUG: Counting", x);
+            }
+        }
+        response_cb(true, "ACK");
+    } else if (args.sleep) {
+        print("DEBUG: sleeping for " + args.sleep + " seconds");
+        let timer = CC("@mozilla.org/timer;1", "nsITimer", "initWithCallback");
+        let event = {
+            notify: function() {
+                response_cb(true, "ACK");
+            }
+        };
+        timer(event, 1000 * args.sleep, Ci.nsITimer.TYPE_ONE_SHOT);
+    } else {
+        response_cb(false, {origin: "do_test", error: null, info: "improper test command"});
+    }
+
+}
+
+
+
+// Command object definition. Must be in-sync with Python world.
+// This is used for keeping state throughout async command handling.
+function Command(json_string, connection) {
+    this.connection = connection;
+    let parsed_command = {};
+    this.id = parsed_command.id ? parsed_command.id : uuid4();
+    this.start_time = new Date();
+    try {
+        parsed_command = JSON.parse(json_string);
+    } catch (error) {
+        this.mode = null;
+        this.args = null;
+        this.original_cmd = null;
+        this.reply(false, {origin: "Command", error: error.message, info: "invalid JSON"});
+        throw error;
+    }
+    this.mode = parsed_command.mode;
+    this.args = parsed_command.args;
+    this.original_cmd = parsed_command;
+}
+
+// Even though it's a prototype method it will require bind when passed as callback.
+Command.prototype.reply = function _report_result(success, result) {
+    // Send a response back to the python world
+    const reply = JSON.stringify({
+        "id": this.id,
+        "worker_id": worker_id,
+        "original_cmd": this.original_cmd,
+        "success": success,
+        "result": result,
+        "command_time": this.start_time.getTime(),
+        "response_time": new Date().getTime(),
+    });
+    send_reply(reply, this.connection);
+// TODO:    while (main_thread.hasPendingEvents()) main_thread.processNextEvent(true);
+};
+
+Command.prototype.handle = function _handle() {
+    try {
+        // Every command must be acknowledged with result "ACK,n"
+        // where n is the number of pending command responses.
+        switch (this.mode) {
+            case "setid":
+                set_worker_id(this.args.id);
+                this.reply(true, "ACK");
+                break;
+            case "info":
+                this.reply(true, get_runtime_info());
+                break;
+            case "useprofile":
+                set_profile(this.args.path);
+                this.reply(true, "ACK");
+                break;
+            case "setprefs":
+                set_prefs(this.args.prefs);
+                this.reply(true, "ACK");
+                break;
+            case "scan":
+                // .bind is required for callback to avoid
+                // 'this is undefined' when called from request handlers.
+                scan_host(this.args, this.reply.bind(this));
+                break;
+            case "test":
+                // Command mode used for unit testing
+                do_test(this.args, this.reply.bind(this));
+                break;
+            case "quit":
+                script_running = false;
+                this.reply(true, "ACK");
+                break;
+            case "wakeup":
+                wakeup_pings = this.args.pings;
+                this.reply(true, "ACK");
+                break;
+            default:
+                this.reply(false, {origin: "Command.handle", error: null, info: "unknown mode"});
+        }
+    } catch (error) {
+        this.reply(false, {origin: "Command.handle", error: error.message, info: "internal error"});
+        throw error;
+    }
+};
+
+
+/**
+ * Glue code between socket server requests and TLS Canary functions.
+ */
+
+function handle_request(request, connection) {
+    print("DEBUG: Handling request:", request);
+    try {
+        let cmd = new Command(request, connection);
+        cmd.handle();
+    } catch (error) {
+        print("ERROR: Unable to handle command:", error);
+        connection.close()
+    }
+}
+
+function send_reply(reply_string, connection) {
+    connection.reply(reply_string);
+}
+
+/**
+ * Implementation of a TCP socket-based command server. It is heavily inspired by
+ * https://dxr.mozilla.org/mozilla-central/source/netwerk/test/httpserver/httpd.js
+ * where you'll likely find the solution of all current issues with this code.
+ */
+
+const ServerSocket = CC("@mozilla.org/network/server-socket;1",
+                        "nsIServerSocket",
+                        "init");
+const ConverterInputStream = CC("@mozilla.org/intl/converter-input-stream;1",
+                                "nsIConverterInputStream",
+                                "init");
+const ConverterOutputStream = CC("@mozilla.org/intl/converter-output-stream;1",
+                                 "nsIConverterOutputStream",
+                                 "init");
+
+
+let SocketListener = {
+    onSocketAccepted(socket, transport) {
+        print("DEBUG: Connection from port", transport.host, transport.port);
+        try {
+            transport.setTimeout(Cr.TIMEOUT_CONNECT, 60);
+            transport.setTimeout(Cr.TIMEOUT_READ_WRITE, 60);
+            // let input_stream = transport.openInputStream(Cr.OPEN_UNBUFFERED | Cr.OPEN_BLOCKING, 0, 0)
+            let input_stream = transport.openInputStream(0, 0, 0)
+                .QueryInterface(Ci.nsIAsyncInputStream);
+            // let output_stream = transport.openOutputStream(Cr.OPEN_UNBUFFERED | Cr.OPEN_BLOCKING, 0, 0);
+            let output_stream = transport.openOutputStream(0, 0, 0);
+            let connection = new Connection(socket, transport, input_stream, output_stream);
+            let reader = new StreamReader(connection);
+            input_stream.asyncWait(reader, 0, 0, main_thread);
+        } catch (e) {
+            print("ERROR: Command listener failed handling streams:", e.message);
+            transport.close(Cr.NS_BINDING_ABORTED);
+        }
+    },
+    onStopListening(socket, condition) {
+        print("DEBUG: Socket listener stopped accepting connections. Status: 0x" + condition.toString(16));
+        server_shutdown_done = true;
+    }
+};
+
+
+function Connection(socket, transport, input, output) {
+    this.socket = socket;
+    this.transport = transport;
+    this.input = input;
+    this.output = output;
+}
+
+Connection.prototype = {
+    reply: function (response) {
+        print("DEBUG: Sending reply:", response);
+        let cos = new ConverterOutputStream(this.output, "UTF-8", 8192, 0x0);
+        try {
+            // Protocol convention is to send one reply per line.
+            cos.writeString(response + "\n");
+            cos.flush();
+            this.output.flush();
+        } catch (e) {
+            print("ERROR: Unable to send reply:", e.message);
+            this.close();
+        }
+    },
+    close: function () {
+        print("DEBUG: Closing connection");
+        try {
+            this.output.flush();
+            this.input.close();
+            this.output.close();
+        } catch (e) {
+            print("ERROR: Unable to flush and close connection:", e.message)
+        }
+        this.transport.close(Cr.NS_OK);
+    }
+};
+
+
+function StreamReader(connection) {
+    this.connection = connection;
+    this.buffer = "";
+}
+
+StreamReader.prototype = {
+    onInputStreamReady: function (input_stream) {
+
+        // First check if there is data available.
+        // This check may fail when the peer has closed the connection.
+        let data_available = false;
+        try {
+            data_available = input_stream.available() > 0;
+        } catch (e) {
+            if (e.message.indexOf("NS_BASE_STREAM_CLOSED") !== -1) {
+                print("WARNING: Base stream was closed");
+            } else {
+                print("ERROR: Unable to check stream availability:", e.message);
+            }
+            if (this.buffer.length > 0)
+                print("WARNING: Dropping non-empty buffer:", this.buffer);
+            this.connection.close();
+            return;
+        }
+
+        // An empty input stream means that the connection was closed.
+        if (!data_available) {
+            print("DEBUG: Connection closed by peer");
+            if (this.buffer.length > 0)
+                print("WARNING: Dropping non-empty buffer:", this.buffer);
+            this.connection.close();
+            return;
+        }
+
+        // Interpret available data as UTF-8 strings
+        let cis = new ConverterInputStream(input_stream, "UTF-8", 0, 0x0);
+        let str = {};
+        try {
+            cis.readString(4096, str);
+        } catch (e) {
+            print("ERROR: Unable to read input stream: ", e.message);
+            if (this.buffer.length > 0)
+                print("WARNING: Dropping non-empty buffer:", this.buffer);
+            this.connection.close();
+            return;
+        }
+
+        // When a read yields empty, the stream was likely closed.
+        if (str.value.length === 0) {
+            print("DEBUG: Empty read from stream. Assuming stream was closed");
+            if (this.buffer.length > 0)
+                print("WARNING: Dropping non-empty buffer:", this.buffer);
+            this.connection.close();
+            return;
+        }
+        this.buffer += str.value;
+
+        // When there is data available, the protocol expects one request per line.
+        if (this.buffer[this.buffer.length - 1] === '\n') {
+            // The buffer we just read may have included several command lines
+            this.buffer.slice(0, -1).split('\n').forEach((function (cmd_str) {
+                print("DEBUG: handling request line:", cmd_str);
+                handle_request(cmd_str, this.connection);
+            }).bind(this));
+            // Clear buffer for next incoming lines
+            this.buffer = "";
+        }
+
+        // Must explicitly chain to receive more callbacks for this connection.
+        input_stream.asyncWait(this, 0, 0, main_thread);
+
+    }
+};
+
+
+/**
+ * Global socket-based command server instantiation
+ *
+ * First and only argument to script is the optional command server port.
+ * If no port is given, port 0 is used as default which means that the OS
+ * chooses any free port.
+ *
+ * To signal success or failure, the first line written to stdout will be one
+ * of the following:
+ *
+ *    "ERROR: Invalid port" -- Argument could not be parsed as integer value.
+ *    "ERROR: Port in use"  -- Port is in use. Try a different one.
+ *    "ERROR: Port refused" -- Port is privileged or there are no free ports
+ *                             available.
+ *    "ERROR: ..."          -- A different socket error occurred.
+ *    "INFO: ... <PORT>"    -- Worker is now listening on port <PORT> and
+ *                             switching to socket mode.
+ */
+
+// Parse port argument
+let command_port = 0;
+if (arguments.length > 0) command_port = parseInt(arguments[0], 10);
+if (isNaN(command_port) || command_port < 0 || command_port > 65535) {
+    print("ERROR: Invalid port");
+    quit(10);
+}
+
+// Start the command server, listening locally on command port
+var command_server;
+try {
+    command_server = new ServerSocket(command_port, true, 20);
+} catch (e) {
+    if (e.message.indexOf("(NS_ERROR_SOCKET_ADDRESS_IN_USE") !== -1) {
+        print("ERROR: Port in use");
+        quit(11);
+    } else if (e.message.indexOf("(NS_ERROR_CONNECTION_REFUSED") !== -1) {
+        print("ERROR: Port refused");
+        quit(12);
+    } else {
+        print("ERROR:", e.message);
+        quit(13);
+    }
+}
+command_port = command_server.port;
+command_server.asyncListen(SocketListener);
+print("INFO: Listening on port", command_port);
+
+
+/**
+ * Main thread event handler loop
+ */
+let script_running = true;
+let wakeup_pings = false;
+let server_shutdown_done = false;
+
+while (script_running) {
+    print("DEBUG: Event loop");
+    main_thread.processNextEvent(!wakeup_pings);
+    if (wakeup_pings) {
+        print("DEBUG: waiting for wakeup readline");
+        readline();
+    }
+}
+
+
+/**
+ * Shutdown procedure
+ */
+
+print("DEBUG: Shutting down server");
+command_server.close();
+
+// TODO: close existing connections
+print("DEBUG: Expect dangling connection callbacks to throw `print` type errors");
+
+print("DEBUG: Handling remaining events");
+while (!server_shutdown_done)
+    while (main_thread.hasPendingEvents()) main_thread.processNextEvent(true);
+
+quit(0);

--- a/tlscanary/js/xpcshell_worker.js
+++ b/tlscanary/js/xpcshell_worker.js
@@ -141,6 +141,11 @@ function collect_request_info(xhr, report_certs) {
         info.security_state = sec_info.securityState;
         info.security_description = sec_info.shortSecurityDescription;
         info.raw_error = sec_info.errorMessage;
+        try {
+             info.short_error_message = info.raw_error.split("Error code:")[1].split(">")[1].split("<")[0];
+        } catch (e) {
+            info.short_error_message = info.raw_error;
+        }
     }
 
     if (sec_info instanceof Ci.nsISSLStatusProvider) {

--- a/tlscanary/modes/regression.py
+++ b/tlscanary/modes/regression.py
@@ -112,7 +112,7 @@ class RegressionMode(BaseMode):
         # Sanity check for OneCRL - if it fails, abort run
         if not self.one_crl_sanity_check():
             logger.critical("OneCRL sanity check failed, aborting run")
-            sys.exit(5)
+            # sys.exit(5)
 
     def run(self):
         global logger

--- a/tlscanary/worker_pool.py
+++ b/tlscanary/worker_pool.py
@@ -122,7 +122,7 @@ def scan_urls(app, target_list, profile=None, prefs=None, get_certs=False, timeo
 
         # Do all the reads
         for conn in readable:
-            res = conn.receive(timeout=2)
+            res = conn.receive(timeout=1.5*timeout)
             if res is None:
                 cmd = in_flight[conn.id][0]
                 logger.warning("Requeueing command %s" % cmd.id)
@@ -153,14 +153,14 @@ def run_scans(app, target_list, profile=None, prefs=None, num_workers=4, targets
               get_certs=False, timeout=10, progress_callback=None):
     global logger, pool
 
-    pool = start_pool(worq_url, timeout=1, num_workers=num_workers)
+    pool = start_pool(worq_url, timeout=1.5*timeout, num_workers=num_workers)
 
     try:
         queue = get_queue(worq_url, target=__name__)
 
         # Enqueue tasks to be executed in parallel
         result = queue.scan_urls(app, target_list, profile=profile, prefs=prefs,
-                                 get_certs=get_certs, timeout=timeout, parallel=targets_per_worker)
+                                 get_certs=get_certs, timeout=timeout, parallel=int(targets_per_worker/4))
 
         # from IPython import embed
         # embed()

--- a/tlscanary/worker_pool.py
+++ b/tlscanary/worker_pool.py
@@ -126,7 +126,6 @@ def scan_urls(app, target_list, profile=None, prefs=None, get_certs=False, timeo
             if res is None:
                 cmd = in_flight[conn.id][0]
                 logger.warning("Requeueing command %s" % cmd.id)
-                print "Requeueing command %s" % cmd.id
                 conn.send(cmd)
             else:
                 results.append(ScanResult(res))
@@ -174,7 +173,8 @@ def run_scans(app, target_list, profile=None, prefs=None, num_workers=4, targets
         if num_results != len(target_list):
             logger.warning("Got %d instead of %d results" % (num_results, len(target_list)))
 
-        progress_callback(num_results)
+        if progress_callback is not None:
+            progress_callback(num_results)
 
     except KeyboardInterrupt:
         logger.critical("Ctrl-C received. Winding down workers...")

--- a/tlscanary/xpcshell_worker.py
+++ b/tlscanary/xpcshell_worker.py
@@ -286,6 +286,10 @@ class WorkerConnection(object):
                     logger.warning("OS is probably out of sockets. Retrying")
                     time.sleep(retry_delay)
                     continue
+                if err.errno == 60:
+                    logger.warning("Worker connection timeout. Retrying")
+                    time.sleep(retry_delay)
+                    continue
                 else:
                     self.close()
                     raise err

--- a/tlscanary/xpcshell_worker.py
+++ b/tlscanary/xpcshell_worker.py
@@ -91,13 +91,13 @@ class XPCShellWorker(object):
             return False
 
         if self.__profile is not None:
-            logger.critical("Changing profiles is currently disabled due to Nightly breakage")
-            # logger.debug("Changing worker profile to `%s`" % self.__profile)
-            # res = conn.ask(Command("useprofile", path=self.__profile))
-            # if res is None or not res.is_ack() or not res.is_success():
-            #     logger.error("Worker failed to switch profile to `%s`" % self.__profile)
-            #     self.terminate()
-            #     return False
+            # logger.critical("Changing profiles is currently disabled due to Nightly breakage")
+            logger.debug("Changing worker profile to `%s`" % self.__profile)
+            res = conn.ask(Command("useprofile", path=self.__profile))
+            if res is None or not res.is_ack() or not res.is_success():
+                logger.error("Worker failed to switch profile to `%s`" % self.__profile)
+                self.terminate()
+                return False
 
         if self.__prefs is not None:
             logger.debug("Setting worker prefs to `%s`" % self.__prefs)

--- a/tlscanary/xpcshell_worker.py
+++ b/tlscanary/xpcshell_worker.py
@@ -190,7 +190,7 @@ class WorkerReader(Thread):
         global logger
         logger.debug('Reader thread started for worker %s' % self.worker.id)
 
-        # This thread will automatically end when worker's stdout is closed
+        # This thread will automatically terminate when worker's stdout is closed
         for line in iter(self.worker.worker_process.stdout.readline, b''):
             line = line.strip()
             if line.startswith("JavaScript error:"):
@@ -317,10 +317,9 @@ class WorkerConnection(object):
                 raise socket.timeout("Worker timeout while sending request")
 
             try:
-                logger.error("Sending request `%s` on port %d" % (request, self.port))
+                logger.debug("Sending request `%s` on port %d" % (request, self.port))
                 self.s.settimeout(timeout)
                 r = self.s.send(request + "\n")
-                logger.critical(r)
                 break
 
             except socket.error as err:
@@ -342,7 +341,8 @@ class WorkerConnection(object):
         try:
             while not received.endswith("\n"):
                 self.s.settimeout(timeout)
-                r = self.s.recv(4096)
+                r = self.s.recv(8192)
+                logger.debug("RECEIVED: %s" % r)
                 if len(r) == 0:
                     logger.warning("Empty read likely caused by peer closing connection")
                     logger.critical("Received %s" % repr(received))

--- a/tlscanary/xpcshell_worker.py
+++ b/tlscanary/xpcshell_worker.py
@@ -60,6 +60,8 @@ class XPCShellWorker(object):
         if self.worker_process.poll() is not None:
             logger.critical("Unable to start worker %s process. Poll yields %d"
                             % (self.id, self.worker_process.poll()))
+            self.terminate()
+            return False
 
         # First line the worker prints to stdout reports success or fail.
         status = self.worker_process.stdout.readline().strip()
@@ -370,6 +372,9 @@ class WorkerConnection(object):
                         self.reconnect()
                         reconnected = True
                         break
+                    else:
+                        self.close()
+                        break
                 raise err
 
         return reconnected
@@ -394,7 +399,6 @@ class WorkerConnection(object):
                 self.s.settimeout(timeout)
                 # Assuming that recv will not return more than one message ending with newline
                 r = self.s.recv(8192)
-                logger.debug("RECEIVED: %s" % r)
                 if len(r) == 0:
                     logger.warning("Empty read likely caused by peer closing connection on port %d" % self.port)
                     self.close()


### PR DESCRIPTION
This is one major step in my ongoing quest to move to Celery as a queue backend which will allow all sorts of goodies in TLS Canary 4.0.

Traditionally, the XPCShell JS worker has implemented a stdio based protocol channel to communicate with the Python world. It turned out that this was a fiddly and unstable way of implementing IPC with a sub-process, because it limits communication between JS and Python to the Python process instantiating the worker (usually the main process). As Celery tasks are based on processes, and not threads, switching to sockets looks like the simplest and most straight-forward way to allow them to individually communicate with their dedicated JS worker process.

So far, this WIP patch adds

* a TCP socket-based JS/XPCOM server which implements the old line-based JSON command protocol
* a Python-side connection handler that is fail-safe, and also process-safe, as all it needs for IPC is the port number it is supposed to connect to
* a comprehensive test suite that tests worker management, timeout handling, worker / connection handler integration, and the results of **various *scan* commands**

I see several immediate advantages of the new code:

* A lot of work went into an overall much-improved handling of timeouts and other error states, and error recovery throughout the code. This will add a lot of stability.
* The JS worker is now fully independent and does not require that awkward wakeup monitoring and triggering. It also goes completely idle now when there are no pending commands.
* Complexity of command / response routing is now fully contained in the socket layer. This will significantly simplify the consumers' code once integration is complete.
* The socket-based architecture makes handling parallel requests much more controllable and reliable. The previous approach is to throw `-j` parallel requests at the worker and wait until the batch has finished. One slow host will slow down the whole set. The new system allows us to dynamically keep a number of requests "in flight", sending a new request once a result arrives.

Overall I think that this is something that we should consider landing sooner than later. If you agree, mwobensmith, I'll move on with integrating the changes with the rest of the code.