### PR TITLE
Replacing obsolete nsILocalFile with nsIFile

### DIFF
--- a/tlscanary/js/scan_worker.js
+++ b/tlscanary/js/scan_worker.js
@@ -60,7 +60,7 @@ function set_prefs(prefs) {
 
 function set_profile(profile_path) {
     let file = Cc["@mozilla.org/file/local;1"]
-        .createInstance(Ci.nsILocalFile);
+        .createInstance(Ci.nsIFile);
     file.initWithPath(profile_path);
     let dir_service = Cc["@mozilla.org/file/directory_service;1"]
         .getService(Ci.nsIProperties);


### PR DESCRIPTION
This is fixing #123 preventing the XPCShell worker from switching to a new profile.