### PR TITLE
Improve regression mode to support configurable scans and caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 sudo: required
 os:
-  - linux
-# OS X python is currently broken due to SSL include problems
-# See
+# Travis' Mac OS X python environment is broken due to SSL include problems.
+# We're hence bootstrapping regular containers.
+# 
+# Linux testing temporarily disabled due to version conflict in
+# `six` dependencies (1.5 vs. 1.6)
+#   - linux
   - osx
 dist: trusty
 

--- a/tlscanary/modes/basemode.py
+++ b/tlscanary/modes/basemode.py
@@ -69,9 +69,9 @@ class BaseMode(object):
                            action="store",
                            default="production")
         group.add_argument("--onecrlpin",
-                           help="OneCRL-Tools git commit to use (default: 244e704)",
+                           help="OneCRL-Tools git commit to use (default: 3bf3462)",
                            action="store",
-                           default="244e704")
+                           default="3bf3462")
         group.add_argument("-p", "--prefs",
                            help="Prefs to apply to all builds",
                            type=str,
@@ -87,6 +87,10 @@ class BaseMode(object):
                            type=str,
                            action="append",
                            default=None)
+        group.add_argument("-c", "--cache",
+                           help='Allow profiles to cache web content',
+                           action="store_true",
+                           default=False)
 
         group = parser.add_argument_group("host database selection")
         group.add_argument("-s", "--source",
@@ -240,10 +244,12 @@ class BaseMode(object):
             # leave the existing revocations file alone
             logger.info("Testing with custom OneCRL entries from default profile")
 
-        # make all files in profiles read-only to prevent caching
-        for root, dirs, files in os.walk(new_profile_dir, topdown=False):
-            for name in files:
-                os.chmod(os.path.join(root, name), stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        logger.debug("Allow profile cache: %s " % self.args.cache)
+        if not self.args.cache:
+            # make all files in profiles read-only to prevent caching
+            for root, dirs, files in os.walk(new_profile_dir, topdown=False):
+                for name in files:
+                    os.chmod(os.path.join(root, name), stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 
         return new_profile_dir
 

--- a/tlscanary/modes/basemode.py
+++ b/tlscanary/modes/basemode.py
@@ -62,6 +62,10 @@ class BaseMode(object):
                            default=base_default)
 
         group = parser.add_argument_group("profile setup")
+        group.add_argument("-c", "--cache",
+                           help='Allow profiles to cache web content',
+                           action="store_true",
+                           default=False)
         group.add_argument("-o", "--onecrl",
                            help="OneCRL set to test (default: production)",
                            type=str.lower,
@@ -87,10 +91,6 @@ class BaseMode(object):
                            type=str,
                            action="append",
                            default=None)
-        group.add_argument("-c", "--cache",
-                           help='Allow profiles to cache web content',
-                           action="store_true",
-                           default=False)
 
         group = parser.add_argument_group("host database selection")
         group.add_argument("-s", "--source",
@@ -244,7 +244,7 @@ class BaseMode(object):
             # leave the existing revocations file alone
             logger.info("Testing with custom OneCRL entries from default profile")
 
-        logger.debug("Allow profile cache: %s " % self.args.cache)
+        logger.debug("Allow profile cache: %s" % self.args.cache)
         if not self.args.cache:
             # make all files in profiles read-only to prevent caching
             for root, dirs, files in os.walk(new_profile_dir, topdown=False):

--- a/tlscanary/modes/basemode.py
+++ b/tlscanary/modes/basemode.py
@@ -119,6 +119,11 @@ class BaseMode(object):
                            type=int,
                            action="store",
                            default=50)
+        group.add_argument("-u", "--max_timeout",
+                           help="Maximum timeout for worker requests (default: 20)",
+                           type=float,
+                           action="store",
+                           default=20)
         group.add_argument("-x", "--scans",
                            help="Number of scans per host (default: 3)",
                            type=int,

--- a/tlscanary/modes/regression.py
+++ b/tlscanary/modes/regression.py
@@ -13,12 +13,10 @@ import tlscanary.progress as pr
 import tlscanary.runlog as rl
 import tlscanary.sources_db as sdb
 
-
 logger = logging.getLogger(__name__)
 
 
 class RegressionMode(BaseMode):
-
     name = "regression"
     help = "Run a TLS regression test on two Firefox versions"
 
@@ -40,12 +38,17 @@ class RegressionMode(BaseMode):
     def setup(self):
         global logger
 
-        # Argument validation logic to make sure user has test build
+        # Argument validation logic
+        # Make sure user has test build
         if self.args.test is None:
             logger.critical("Must specify test build for regression testing")
             sys.exit(5)
         elif self.args.base is None:
             logger.critical("Must specify base build for regression testing")
+            sys.exit(5)
+
+        if self.args.scans < 2:
+            logger.critical("Must specify minimum of 2 scans for regression testing")
             sys.exit(5)
 
         if self.args.prefs is not None:
@@ -91,12 +94,12 @@ class RegressionMode(BaseMode):
         rldb = rl.RunLogDB(self.args)
         log = rldb.new_log()
         log.start(meta=meta)
-        progress = pr.ProgressTracker(total=len(self.sources), unit="hosts", average=30*60.0)
+        progress = pr.ProgressTracker(total=len(self.sources), unit="hosts", average=30 * 60.0)
 
         limit = len(self.sources) if self.args.limit is None else self.args.limit
 
         # Split work into 50 chunks to conserve memory, but make no chunk smaller than 1000 hosts
-        next_chunk = self.sources.iter_chunks(chunk_size=limit/50, min_chunk_size=1000)
+        next_chunk = self.sources.iter_chunks(chunk_size=limit / 50, min_chunk_size=1000)
 
         try:
             while True:
@@ -130,99 +133,82 @@ class RegressionMode(BaseMode):
 
     def run_regression_passes(self, host_set, report_completed=None, report_overhead=None):
         global logger
+        # Compile set of error hosts in multiple scans
 
-        # Compile set of error hosts in three passes
+        # Each scan:
+        # - Runs full test set against the test candidate
+        # - Runs new error set against baseline candidate
+        # - Take any remaining errors and repeat the above steps
 
-        # First pass:
-        # - Run full test set against the test candidate
-        # - Run new error set against baseline candidate
-        # - Filter for errors from test candidate but not baseline
+        current_host_set = host_set
+        current_scan = 0
 
-        logger.info("Starting first pass with %d hosts" % len(host_set))
+        while current_scan < self.args.scans:
+            # Slow down number of workers and scans with each pass
+            # to make results more precise
+            scans_remaining = self.args.scans - current_scan
+            current_scan += 1
+            pct_remaining = (float(scans_remaining) / float(self.args.scans))
+            adjusted_workers = int(ceil(self.args.parallel * pct_remaining))
+            adjusted_requests_per_worker = int(ceil(self.args.requestsperworker * pct_remaining))
 
-        test_error_set = self.run_test(self.test_app, host_set, profile=self.test_profile,
-                                       prefs=self.args.prefs_test, report_callback=report_completed)
-        logger.info("First test candidate pass yielded %d error hosts" % len(test_error_set))
-        logger.debug("First test candidate pass errors: %s"
-                     % ' '.join(["%d,%s" % (r, u) for r, u in test_error_set]))
+            # Specify different callback only for initial test scan
+            if current_scan == 1:
+                report_callback_value = report_completed
+            else:
+                report_callback_value = report_overhead
 
-        base_error_set = self.run_test(self.base_app, test_error_set, profile=self.base_profile,
-                                       prefs=self.args.prefs_base, report_callback=report_overhead)
-        logger.info("First baseline candidate pass yielded %d error hosts" % len(base_error_set))
-        logger.debug("First baseline candidate pass errors: %s"
-                     % ' '.join(["%d,%s" % (r, u) for r, u in base_error_set]))
+            # Actual test running for both builds
+            test_error_set = self.run_test(self.test_app, current_host_set, profile=self.test_profile,
+                                           prefs=self.args.prefs_test, num_workers=adjusted_workers,
+                                           n_per_worker=adjusted_requests_per_worker,
+                                           report_callback=report_callback_value)
+            logger.info("Scan #%d with test candidate yielded %d error hosts"
+                        % (current_scan, len(test_error_set)))
+            logger.debug("Scan #%d test candidate errors: %s"
+                         % (current_scan, ' '.join(["%d,%s" % (r, u) for r, u in test_error_set])))
+            base_error_set = self.run_test(self.base_app, test_error_set, profile=self.base_profile,
+                                           prefs=self.args.prefs_base, num_workers=adjusted_workers,
+                                           n_per_worker=adjusted_requests_per_worker,
+                                           report_callback=report_overhead)
+            logger.info("Scan #%d with baseline candidate yielded %d error hosts"
+                        % (current_scan, len(base_error_set)))
+            logger.debug("Scan #%d baseline candidate errors: %s"
+                         % (current_scan, ' '.join(["%d,%s" % (r, u) for r, u in base_error_set])))
 
-        error_set = test_error_set.difference(base_error_set)
+            current_host_set = test_error_set.difference(base_error_set)
 
-        # Second pass:
-        # - Run error set from first pass against the test candidate
-        # - Run new error set against baseline candidate, slower with higher timeout
-        # - Filter for errors from test candidate but not baseline
+            # If no errors, no need to keep scanning
+            if len(current_host_set) == 0:
+                break
 
-        logger.info("Starting second pass with %d hosts" % len(error_set))
+        last_error_set = current_host_set
 
-        test_error_set = self.run_test(self.test_app, error_set, profile=self.test_profile,
-                                       prefs=self.args.prefs_test,
-                                       num_workers=int(ceil(self.args.parallel / 1.414)),
-                                       n_per_worker=int(ceil(self.args.requestsperworker / 1.414)),
-                                       report_callback=report_overhead)
-        logger.info("Second test candidate pass yielded %d error hosts" % len(test_error_set))
-        logger.debug("Second test candidate pass errors: %s"
-                     % ' '.join(["%d,%s" % (r, u) for r, u in test_error_set]))
-
-        base_error_set = self.run_test(self.base_app, test_error_set, profile=self.base_profile,
-                                       prefs=self.args.prefs_base, report_callback=report_overhead)
-        logger.info("Second baseline candidate pass yielded %d error hosts" % len(base_error_set))
-        logger.debug("Second baseline candidate pass errors: %s"
-                     % ' '.join(["%d,%s" % (r, u) for r, u in base_error_set]))
-
-        error_set = test_error_set.difference(base_error_set)
-
-        # Third pass:
-        # - Run error set from first pass against the test candidate with less workers
-        # - Run new error set against baseline candidate with less workers
-        # - Filter for errors from test candidate but not baseline
-
-        logger.info("Starting third pass with %d hosts" % len(error_set))
-
-        test_error_set = self.run_test(self.test_app, error_set, profile=self.test_profile,
-                                       prefs=self.args.prefs_test, num_workers=2, n_per_worker=10,
-                                       report_callback=report_overhead)
-        logger.info("Third test candidate pass yielded %d error hosts" % len(test_error_set))
-        logger.debug("Third test candidate pass errors: %s"
-                     % ' '.join(["%d,%s" % (r, u) for r, u in test_error_set]))
-
-        base_error_set = self.run_test(self.base_app, test_error_set, profile=self.base_profile,
-                                       prefs=self.args.prefs_base, num_workers=2, n_per_worker=10,
-                                       report_callback=report_overhead)
-        logger.info("Third baseline candidate pass yielded %d error hosts" % len(base_error_set))
-        logger.debug("Third baseline candidate pass errors: %s"
-                     % ' '.join(["%d,%s" % (r, u) for r, u in base_error_set]))
-
-        error_set = test_error_set.difference(base_error_set)
-        if len(error_set) > 0:
-            logger.warning("%d regressions found: %s"
-                           % (len(error_set), ' '.join(["%d,%s" % (r, u) for r, u in error_set])))
-
-        # Fourth pass, information extraction:
-        # - Run error set from third pass against the test candidate with less workers
+        # Final pass, information extraction only:
+        # - Run error set from previous pass against the test candidate with minimal workers, requests
         # - Have workers return extra runtime information, including certificates
 
-        logger.debug("Extracting runtime information from %d hosts" % (len(error_set)))
-        final_error_set = self.run_test(self.test_app, error_set, profile=self.test_profile,
-                                        prefs=self.args.prefs_test, num_workers=1, n_per_worker=10,
+        logger.debug("Extracting runtime information from %d hosts" % (len(last_error_set)))
+        final_error_set = self.run_test(self.test_app, last_error_set, profile=self.test_profile,
+                                        prefs=self.args.prefs_test, num_workers=1, n_per_worker=1,
                                         get_info=True, get_certs=True,
-                                        return_only_errors=False,  # FIXME: Remove this
                                         report_callback=report_overhead)
 
-        # Final set includes additional result data, so filter that out before comparison
-        stripped_final_set = set()
+        if len(final_error_set) > 0:
+            logger.warning("%d regressions found: %s"
+                           % (len(final_error_set), ' '.join(["%d,%s" % (r, u) for r, u, d in final_error_set])))
 
-        for rank, host, data in final_error_set:
-            stripped_final_set.add((rank, host))
+        # Find out if the information extraction pass changed the results
+        if self.args.debug:
+            # Final set includes additional result data, so filter that out before comparison
+            stripped_final_set = set()
 
-        if stripped_final_set != error_set:
-            diff_set = error_set.difference(stripped_final_set)
-            logger.warning("Domains dropped out of final error set: %s" % diff_set)
+            for rank, host, data in final_error_set:
+                stripped_final_set.add((rank, host))
+
+            if stripped_final_set != last_error_set:
+                diff_set = last_error_set.difference(stripped_final_set)
+                logger.debug("Number of hosts dropped out of final error set: %d" % len(diff_set))
+                logger.debug(diff_set)
 
         return final_error_set

--- a/tlscanary/modes/regression.py
+++ b/tlscanary/modes/regression.py
@@ -145,18 +145,10 @@ class RegressionMode(BaseMode):
         num_workers = self.args.parallel
         requests_per_worker = self.args.requestsperworker
         timeout = self.args.timeout
-        #max_timeout = self.args.max_timeout
-        # temp
-        max_timeout = 30
-        # TODO: add max timeout to CLI
+        max_timeout = self.args.max_timeout
 
         for current_scan in xrange(1, self.args.scans + 1):
-            # Slow down number of workers and scans with each pass
-            # to make results more precise
-
-            num_workers = max(1, int(num_workers * 0.75))
-            requests_per_worker = max(1, int(requests_per_worker * 0.75))
-            timeout = min(max_timeout, timeout * 1.25)
+            logger.info("Current timeout is %f" % timeout)
 
             # Specify different callback only for initial test scan
             if current_scan == 1:
@@ -187,6 +179,12 @@ class RegressionMode(BaseMode):
             # If no errors, no need to keep scanning
             if len(current_host_set) == 0:
                 break
+            else:
+                # Slow down number of workers and scans with each pass
+                # to make results more precise
+                num_workers = max(1, int(num_workers * 0.75))
+                requests_per_worker = max(1, int(requests_per_worker * 0.75))
+                timeout = min(max_timeout, timeout * 1.25)
 
         last_error_set = current_host_set
 

--- a/tlscanary/one_crl_downloader.py
+++ b/tlscanary/one_crl_downloader.py
@@ -40,8 +40,8 @@ def get_list(onecrl_env, workdir, commit, use_cache=True, cache_timeout=60*60):
         go_env["GOPATH"] = go_path
 
         # Install / update oneCRL2RevocationsTxt package
-        package = "github.com/mozmark/OneCRL-Tools/oneCRL2RevocationsTxt"
-        repo_dir = os.path.join(go_path, "src", "github.com", "mozmark", "OneCRL-Tools")
+        package = "github.com/mozilla/OneCRL-Tools/oneCRL2RevocationsTxt"
+        repo_dir = os.path.join(go_path, "src", "github.com", "mozilla", "OneCRL-Tools")
         # If the package has already been downloaded, checkout master, else `go get` will fail
         if os.path.isdir(os.path.join(repo_dir, ".git")):
             logger.debug("Checking out commit `master` in `%s` for update" % repo_dir)


### PR DESCRIPTION
The main scanning logic has been cleaned up and put inside a loop, which iterates based on desired amount of scans. The larger the number of scans, the lower the final error rate.

Also introduced a flag to enable content caching in test profiles, if desired. 

This PR requires changes to OneCRL from PR #130.