### PR TITLE
Final cleanup before 3.2 release

### DIFF
--- a/tests/zz_tlscanary_integration_test.py
+++ b/tests/zz_tlscanary_integration_test.py
@@ -53,7 +53,7 @@ def test_tlscanary_regression_and_log():
     argv = [
         "--workdir", work_dir,
         "log",
-        "-a", "htmlreport",
+        "-a", "webreport",
         "-i", "1",
         "-o", report_dir
     ]
@@ -61,15 +61,12 @@ def test_tlscanary_regression_and_log():
     assert_equal(ret, 0, "regression HTML report finished without error")
     assert_true(os.path.isdir(report_dir), "HTML report dir was created")
     assert_true(os.path.isfile(os.path.join(report_dir, "index.htm")), "HTML report index was written")
-    runs_file = os.path.join(report_dir, "runs", "runs.txt")
-    assert_true(os.path.isfile(runs_file), "HTML `runs.txt` file was written")
-    runs_lines = []
+    runs_file = os.path.join(report_dir, "runs", "runs.json")
+    assert_true(os.path.isfile(runs_file), "HTML `runs.json` file was written")
     with open(runs_file) as f:
-        for line in f.readlines():
-            if len(line) > 0:
-                runs_lines.append(json.loads(line))
+        runs_lines = json.load(f)
     assert_equal(len(runs_lines), 1, "one HTML run was written")
-    run_dir = os.path.join(report_dir, "runs", runs_lines[0]["run"])
+    run_dir = os.path.join(report_dir, "runs", runs_lines[0]["data"][0]["run"])
     assert_true(os.path.isdir(run_dir), "HTML run dir was created")
     zip_glob = glob.glob(os.path.join(run_dir, "*.zip"))
     assert_equal(len(zip_glob), 3, "three profile archives were written to HTML run dir")

--- a/tlscanary/js/scan_worker.js
+++ b/tlscanary/js/scan_worker.js
@@ -16,6 +16,7 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/NetUtil.jsm");
 Cu.import("resource://gre/modules/AppConstants.jsm");
+Cu.importGlobalProperties(["XMLHttpRequest"]);
 
 const nsINSSErrorsService = Ci.nsINSSErrorsService;
 let nssErrorsService = Cc['@mozilla.org/nss_errors_service;1'].getService(nsINSSErrorsService);
@@ -224,7 +225,7 @@ function scan_host(args, response_cb) {
         QueryInterface: XPCOMUtils.generateQI([Ci.nsIChannelEventSink])
     };
 
-    let request = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"].createInstance(Ci.nsIXMLHttpRequest);
+    let request = new XMLHttpRequest();
     try {
         request.mozBackgroundRequest = true;
         request.open("HEAD", "https://" + host, true);

--- a/tlscanary/modes/basemode.py
+++ b/tlscanary/modes/basemode.py
@@ -137,6 +137,9 @@ class BaseMode(object):
                            choices=[0, 1],
                            action="store",
                            default=1)
+        group.add_argument("-r", "--remove_certs",
+                           help="Filter certificate data from results",
+                           action="store_true")
 
     def __init__(self, args, module_dir, tmp_dir):
         self.args = args

--- a/tlscanary/modes/performance.py
+++ b/tlscanary/modes/performance.py
@@ -70,12 +70,12 @@ class PerformanceMode(RegressionMode):
 
         for i in xrange(0, self.args.scans):
             test_uri_sets.append(self.run_test(self.test_app, self.sources, profile=self.test_profile,
-                                               prefs=self.args.prefs_test, get_info=True, get_certs=True,
-                                               return_only_errors=False))
+                                               prefs=self.args.prefs_test, get_info=True,
+                                               get_certs=not self.args.remove_certs, return_only_errors=False))
 
             base_uri_sets.append(self.run_test(self.base_app, self.sources, profile=self.base_profile,
-                                               prefs=self.args.prefs_base, get_info=True, get_certs=True,
-                                               return_only_errors=False))
+                                               prefs=self.args.prefs_base, get_info=True,
+                                               get_certs=not self.args.remove_certs, return_only_errors=False))
 
         # extract connection speed from all scans
         test_connections_all = []

--- a/tlscanary/modes/regression.py
+++ b/tlscanary/modes/regression.py
@@ -237,7 +237,7 @@ class RegressionMode(BaseMode):
         logger.debug("Extracting runtime information from %d hosts" % (len(last_error_set)))
         final_error_set = self.run_test(self.test_app, last_error_set, profile=self.test_profile,
                                         prefs=self.args.prefs_test, num_workers=1, n_per_worker=1,
-                                        get_info=True, get_certs=True,
+                                        get_info=True, get_certs=not self.args.remove_certs,
                                         report_callback=report_overhead)
 
         if len(final_error_set) > 0:

--- a/tlscanary/modes/scan.py
+++ b/tlscanary/modes/scan.py
@@ -97,7 +97,7 @@ class ScanMode(BaseMode):
 
                 info_uri_set = self.run_test(self.test_app, host_set_chunk, profile=self.test_profile,
                                              prefs=self.args.prefs, get_info=True,
-                                             get_certs=True, return_only_errors=False,
+                                             get_certs=not self.args.remove_certs, return_only_errors=False,
                                              report_callback=progress.log_completed)
                 # Log progress per chunk
                 logger.info("Progress: %s" % str(progress))


### PR DESCRIPTION
This PR addresses three issues:

First, it fixes a regression in the integration test that was caused by removing the htmlreport legacy feature which the test depended on. The fix was to switch the test to the webreport feature.

Second, it fixes a regression caused by bug 792808 landing in nightly, removing XPCOM stuff from XHR. This caused the scan worker to produce ```TypeError: Cc['@mozilla.org/xmlextras/xmlhttprequest;1'] is undefined``` errors during scans that reduced TLSCanary to producing "Worker dropped results" warnings.

Third, it adds the ```--remove_certs``` option for preventing certificate data from clogging the logs, as requested by the NSS team in #155.