### PR TITLE
Added --remove_certs or -r command line switch

### DIFF
--- a/tlscanary/modes/basemode.py
+++ b/tlscanary/modes/basemode.py
@@ -137,6 +137,10 @@ class BaseMode(object):
                            choices=[0, 1],
                            action="store",
                            default=1)
+        group.add_argument("-r", "--remove_certs",
+                          help="Remove certificates from results.",
+                          action="store_true",
+                          default=False)
 
     def __init__(self, args, module_dir, tmp_dir):
         self.args = args

--- a/tlscanary/modes/performance.py
+++ b/tlscanary/modes/performance.py
@@ -70,11 +70,11 @@ class PerformanceMode(RegressionMode):
 
         for i in xrange(0, self.args.scans):
             test_uri_sets.append(self.run_test(self.test_app, self.sources, profile=self.test_profile,
-                                               prefs=self.args.prefs_test, get_info=True, get_certs=True,
+                                               prefs=self.args.prefs_test, get_info=True, get_certs=(not self.args.remove_certs),
                                                return_only_errors=False))
 
             base_uri_sets.append(self.run_test(self.base_app, self.sources, profile=self.base_profile,
-                                               prefs=self.args.prefs_base, get_info=True, get_certs=True,
+                                               prefs=self.args.prefs_base, get_info=True, get_certs=(not self.args.remove_certs),
                                                return_only_errors=False))
 
         # extract connection speed from all scans

--- a/tlscanary/modes/regression.py
+++ b/tlscanary/modes/regression.py
@@ -237,7 +237,7 @@ class RegressionMode(BaseMode):
         logger.debug("Extracting runtime information from %d hosts" % (len(last_error_set)))
         final_error_set = self.run_test(self.test_app, last_error_set, profile=self.test_profile,
                                         prefs=self.args.prefs_test, num_workers=1, n_per_worker=1,
-                                        get_info=True, get_certs=True,
+                                        get_info=True, get_certs=(not self.args.remove_certs),
                                         report_callback=report_overhead)
 
         if len(final_error_set) > 0:

--- a/tlscanary/modes/scan.py
+++ b/tlscanary/modes/scan.py
@@ -97,7 +97,7 @@ class ScanMode(BaseMode):
 
                 info_uri_set = self.run_test(self.test_app, host_set_chunk, profile=self.test_profile,
                                              prefs=self.args.prefs, get_info=True,
-                                             get_certs=True, return_only_errors=False,
+                                             get_certs=(not self.args.remove_certs), return_only_errors=False,
                                              report_callback=progress.log_completed)
                 # Log progress per chunk
                 logger.info("Progress: %s" % str(progress))

--- a/tlscanary/modes/sourceupdate.py
+++ b/tlscanary/modes/sourceupdate.py
@@ -154,7 +154,7 @@ class SourceUpdateMode(BaseMode):
                         report_callback = progress.log_overhead
 
                     pass_errors = self.run_test(self.app, pass_errors, profile=self.profile, get_info=False,
-                                                get_certs=False, return_only_errors=True,
+                                                get_certs=(not self.args.remove_certs), return_only_errors=True,
                                                 report_callback=report_callback)
                     len_pass_errors = len(pass_errors)
 


### PR DESCRIPTION
 - Command line switch excludes certificates from run logs

 - Makes logs ~75% smaller