### PR TITLE
Handle error case - no error string

### DIFF
--- a/tlscanary/report.py
+++ b/tlscanary/report.py
@@ -78,7 +78,10 @@ def web_report(log, report_dir):
             # Filter out stray timeout errors
             connection_speed = line["response"]["response_time"]-line["response"]["command_time"]
             timeout = line["response"]["original_cmd"]["args"]["timeout"] * 1000
-            error_message = line["response"]["result"]["info"]["short_error_message"]
+            try:
+                error_message = line["response"]["result"]["info"]["short_error_message"]
+            except KeyError:
+                error_message = "unknown"
             if error_message == "NS_BINDING_ABORTED" and connection_speed > timeout:
                 continue
         uri_data.append(line)


### PR DESCRIPTION
For whatever reason, we sometimes get into a situation where there is no error string to parse, and we fail. This means that the log can't be generated. We need to address this somehow, at the very least with a `try/except` block so that we can work past this.

Ideally we'd find out why we haven't gotten the short error message in the first place, but this is a short-term solution.