### PR TITLE
Fixing urllib import error and certificate enumeration regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The project has a dedicated IRC channel: [#tlscanary on irc.mozilla.org](
 https://mibbit.com/?server=irc.mozilla.org&channel=%23tlscanary). Come talk to us!
 
 ## Requirements
-* Python 2.7
+* Python 3.6+
 * 7zip
 * Go 1.7 or later
 * OpenSSL-dev
@@ -35,7 +35,7 @@ https://mibbit.com/?server=irc.mozilla.org&channel=%23tlscanary). Come talk to u
 ### Dependencies for Debian and Ubuntu users
 Assuming that you run TLS Canary on a regular graphical desktop machine, these are the packages it requires:
 ```
-sudo apt-get install python python-dev gcc golang-go p7zip-full libssl-dev libffi-dev
+sudo apt-get install python3 python3-dev gcc golang-1.9-go p7zip-full libssl-dev libffi-dev
 ```
 
 The script [linux_bootstrap.sh](bootstrap/linux_bootstrap.sh) provides bootstrapping for a headless Ubuntu-based EC2
@@ -58,14 +58,14 @@ but expect minor unicode encoding issues in terminal logging output.
 First, [install Chocolatey](https://chocolatey.org/install), then run the following command in an admin PowerShell
 to install the dependencies:
 ```
-choco install 7zip.commandline git golang openssh python2
+choco install 7zip.commandline git golang openssh python3
 ```
 
 ## For end users
 TLS Canary can be installed as a stable package from PyPI and as experimental package directly from GitHub.
 The following command will install the latest stable release of TLS Canary to your current Python environment:
 ```
-pip install [--user] --upgrade tlscanary
+pip3 install [--user] --upgrade tlscanary
 ```
 
 Whether or not you require the `--user` flag depends on how your Python environment is set up. Most Linux distributions
@@ -73,7 +73,7 @@ require it when not installing Python packages as root.
 
 If you prefer the bleeding-edge developer version with the latest features and added instability, you can run
 ```
-pip install [--user] --upgrade git+git://github.com/mozilla/tls-canary.git
+pip3 install [--user] --upgrade git+git://github.com/mozilla/tls-canary.git
 ```
 
 Once it finishes the `tlscanary` binary is available in your Python environment:
@@ -172,7 +172,7 @@ These are the commands that set you up for TLS Canary development work:
 ```
 git clone https://github.com/mozilla/tls-canary
 cd tls-canary
-virtualenv -p python2.7 venv
+virtualenv -p python3 venv
 source venv/bin/activate
 pip install -e .[dev]
 ```
@@ -186,7 +186,7 @@ with user privileges, should set you up for TLS Canary development:
 ```
 git clone https://github.com/mozilla/tls-canary
 cd tls-canary
-virtualenv -p c:\python27\python.exe venv
+virtualenv -p c:\python36\python.exe venv
 venv\Scripts\activate
 pip install -e .[dev]
 ```

--- a/tlscanary/firefox_downloader.py
+++ b/tlscanary/firefox_downloader.py
@@ -6,7 +6,8 @@ import logging
 import os
 import struct
 import sys
-import urllib
+import urllib.error
+import urllib.request
 
 from . import cache
 

--- a/tlscanary/js/scan_worker.js
+++ b/tlscanary/js/scan_worker.js
@@ -222,7 +222,10 @@ function collect_request_info(xhr, report_certs) {
                 chain = info.ssl_status.failedCertChain;
             }
             let enumerator = chain.getEnumerator();
-            let cert_enumerator = XPCOMUtils.IterSimpleEnumerator(enumerator, Ci.nsIX509Cert);
+
+            // XPCOMUtils.IterSimpleEnumerator removed in Firefox 63 (bug 1484496)
+            let cert_enumerator = XPCOMUtils.IterSimpleEnumerator ?
+                XPCOMUtils.IterSimpleEnumerator(enumerator, Ci.nsIX509Cert) : enumerator;
             for (let cert of cert_enumerator) {
                 cert_chain.push(cert);
             }

--- a/tlscanary/modes/sourceupdate.py
+++ b/tlscanary/modes/sourceupdate.py
@@ -97,7 +97,7 @@ class SourceUpdateMode(BaseMode):
 
         self.start_time = datetime.datetime.now()
 
-        limit = 500000
+        limit = 1000000
         if self.args.limit is not None:
             limit = self.args.limit
 


### PR DESCRIPTION
Firefox 63 dropped XPCOMUtils.IterSimpleEnumerator, leading to JS errors when requesting the full certificate chain.
This patch is switching JS xpcshell worker to iterating the cert chain object directly.
See http://bugzil.la/1484496 for details.