### PR TITLE
tools: xpcshell worker set head_script

### DIFF
--- a/tlscanary/tools/xpcshell_worker.py
+++ b/tlscanary/tools/xpcshell_worker.py
@@ -52,7 +52,7 @@ class XPCShellWorker(object):
         if head_script is None:
             self.__head_script = os.path.join(module_dir, "js", "worker_common.js")
         else:
-            self.__script = script
+            self.__head_script = head_script
         self.__profile = profile
         self.__prefs = prefs
         self.__worker_thread = None


### PR DESCRIPTION
Fix a probable typo in the XPCShell worker where the `head_` prefix was missing and `head_script` never gets set to the the `head_script` arg.

If most uses of the XPCShell worker used the default `head_script`, then this branch might've never been used before.